### PR TITLE
Fix helpdesk tests and add SQLite settings

### DIFF
--- a/helpdesk/tests/test_attachments.py
+++ b/helpdesk/tests/test_attachments.py
@@ -8,7 +8,7 @@ from tempfile import gettempdir
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from django.test import override_settings, TestCase
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 from helpdesk import lib, models
 
@@ -84,7 +84,7 @@ class AttachmentIntegrationTests(TestCase):
         # Ensure attachment is available with correct content
         att = models.Attachment.objects.get(followup__ticket=response.context['ticket'])
         with open(os.path.join(MEDIA_DIR, att.file.name)) as file_on_disk:
-            disk_content = smart_text(file_on_disk.read(), 'utf-8')
+            disk_content = smart_str(file_on_disk.read(), 'utf-8')
         self.assertEqual(disk_content, 'โจ')
 
 

--- a/wbee/settings/settings_test.py
+++ b/wbee/settings/settings_test.py
@@ -1,0 +1,12 @@
+from .base import *
+
+# Use SQLite database for tests
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+# Ensure helpdesk app is active during tests
+INSTALLED_APPS.append('helpdesk.apps.HelpdeskConfig')


### PR DESCRIPTION
## Summary
- set up a SQLite-backed settings module for tests
- update helpdesk attachment tests to use `smart_str`

## Testing
- `DJANGO_SETTINGS_MODULE=wbee.settings.settings_test python manage.py test helpdesk.tests.test_attachments --verbosity 2` *(fails: Field defines a relation with model 'base.Queue', which is either not installed, or is abstract)*

------
https://chatgpt.com/codex/tasks/task_e_6847ba94f3688332b2875b63a05654a0