### PR TITLE
Fix asset data setup and view bug

### DIFF
--- a/asset/models.py
+++ b/asset/models.py
@@ -587,5 +587,22 @@ def setup_asset_choices():
         ('field', 'Field Location'),
     ]
     
-    # Create configurable choices
-    # This would integrate with your ConfigurableChoice system
+    # Create configurable choices using the ConfigurableChoice model
+    choices_to_create = [
+        ('asset_status', asset_statuses),
+        ('asset_location', asset_locations),
+    ]
+
+    for choice_type, values in choices_to_create:
+        for index, (value, display) in enumerate(values):
+            ConfigurableChoice.objects.get_or_create(
+                choice_type=choice_type,
+                value=value,
+                defaults={
+                    'display_name': display,
+                    'sort_order': index * 10,
+                    'applicable_to_all': True,
+                }
+            )
+
+    print("Default asset choices created successfully!")

--- a/asset/views.py
+++ b/asset/views.py
@@ -1407,7 +1407,7 @@ class VehicleListView(AssetListView):
     template_name = 'asset/legacy/vehicle_list.html'
     
     def get_queryset(self):
-        queryset = super().get_context_data()
+        queryset = super().get_queryset()
         return queryset.filter(category__name__icontains='vehicle')
     
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
## Summary
- clean up `setup_asset_choices` to add default status and location choices
- fix `VehicleListView.get_queryset` to use parent's queryset method

## Testing
- `python -m py_compile asset/models.py asset/views.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6847d5edbbd88332bd018a5e780b791f