### PR TITLE
Fix client model URL reversal

### DIFF
--- a/client/models.py
+++ b/client/models.py
@@ -193,9 +193,9 @@ class Client(UUIDModel, TimeStampedModel):
     
     def __str__(self):
         return self.company_name
-    
+
     def get_absolute_url(self):
-        return reverse('client-detail', args=[str(self.id)])
+        return reverse('client:detail', kwargs={'pk': self.pk})
     
     @property
     def primary_address(self):


### PR DESCRIPTION
## Summary
- fix `Client.get_absolute_url` to use namespaced URL

## Testing
- `python manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6847d64ade4083329c143fff49fe08ca