### PR TITLE
Standardize models with shared base classes

### DIFF
--- a/asset/models.py
+++ b/asset/models.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from django.core.validators import MinValueValidator, MaxValueValidator
 from decimal import Decimal
 from datetime import date, timedelta
-import uuid
+from django.utils.translation import gettext_lazy as _
 
 # Import from your modernized apps
 from client.models import TimeStampedModel, UUIDModel
@@ -14,7 +14,34 @@ from company.models import Company, Office, Department
 from hr.models import Worker, JobPosition
 from project.models import Project
 
-class AssetCategory(TimeStampedModel):
+
+class Condition(models.TextChoices):
+    """Normalized condition values for assets"""
+    EXCELLENT = "excellent", _("Excellent")
+    GOOD = "good", _("Good")
+    FAIR = "fair", _("Fair")
+    POOR = "poor", _("Poor")
+    NEEDS_REPAIR = "needs_repair", _("Needs Repair")
+    OUT_OF_SERVICE = "out_of_service", _("Out of Service")
+
+
+class MaintenanceType(models.TextChoices):
+    """Types of maintenance that can be performed"""
+    ROUTINE = "routine", _("Routine Maintenance")
+    REPAIR = "repair", _("Repair")
+    INSPECTION = "inspection", _("Inspection")
+    UPGRADE = "upgrade", _("Upgrade")
+    CALIBRATION = "calibration", _("Calibration")
+
+
+class DepreciationMethod(models.TextChoices):
+    """Methods for asset depreciation"""
+    STRAIGHT_LINE = "straight_line", _("Straight Line")
+    DECLINING_BALANCE = "declining_balance", _("Declining Balance")
+    SUM_OF_YEARS = "sum_of_years", _("Sum of Years Digits")
+    UNITS_OF_PRODUCTION = "units_of_production", _("Units of Production")
+
+class AssetCategory(UUIDModel, TimeStampedModel):
     """Configurable asset categories for different business types"""
     business_category = models.ForeignKey(
         BusinessCategory,
@@ -174,18 +201,10 @@ class Asset(UUIDModel, TimeStampedModel):
     )
     
     # Condition and maintenance
-    CONDITION_CHOICES = [
-        ('excellent', 'Excellent'),
-        ('good', 'Good'),
-        ('fair', 'Fair'),
-        ('poor', 'Poor'),
-        ('needs_repair', 'Needs Repair'),
-        ('out_of_service', 'Out of Service'),
-    ]
     condition = models.CharField(
         max_length=20,
-        choices=CONDITION_CHOICES,
-        default='good'
+        choices=Condition.choices,
+        default=Condition.GOOD,
     )
     
     # Maintenance tracking
@@ -356,18 +375,14 @@ class Asset(UUIDModel, TimeStampedModel):
         self.schedule_next_maintenance()
         self.save()
 
-class AssetMaintenanceRecord(TimeStampedModel):
+class AssetMaintenanceRecord(UUIDModel, TimeStampedModel):
     """Track maintenance history for assets"""
     asset = models.ForeignKey(Asset, on_delete=models.CASCADE, related_name='maintenance_records')
     
-    MAINTENANCE_TYPES = [
-        ('routine', 'Routine Maintenance'),
-        ('repair', 'Repair'),
-        ('inspection', 'Inspection'),
-        ('upgrade', 'Upgrade'),
-        ('calibration', 'Calibration'),
-    ]
-    maintenance_type = models.CharField(max_length=20, choices=MAINTENANCE_TYPES)
+    maintenance_type = models.CharField(
+        max_length=20,
+        choices=MaintenanceType.choices,
+    )
     
     description = models.TextField(help_text='Description of work performed')
     
@@ -394,11 +409,14 @@ class AssetMaintenanceRecord(TimeStampedModel):
     
     class Meta:
         ordering = ['-performed_date']
+        indexes = [
+            models.Index(fields=['asset', 'performed_date']),
+        ]
     
     def __str__(self):
         return f"{self.asset.asset_number} - {self.maintenance_type} on {self.performed_date}"
 
-class AssetAssignment(TimeStampedModel):
+class AssetAssignment(UUIDModel, TimeStampedModel):
     """Track asset assignments over time"""
     asset = models.ForeignKey(Asset, on_delete=models.CASCADE, related_name='assignments')
     
@@ -440,22 +458,24 @@ class AssetAssignment(TimeStampedModel):
     
     class Meta:
         ordering = ['-start_date']
+        indexes = [
+            models.Index(fields=['asset', 'is_active']),
+            models.Index(fields=['assigned_to_worker']),
+        ]
     
     def __str__(self):
         return f"{self.asset.asset_number} assigned on {self.start_date}"
 
-class AssetDepreciation(TimeStampedModel):
+class AssetDepreciation(UUIDModel, TimeStampedModel):
     """Track depreciation schedules for assets"""
     asset = models.ForeignKey(Asset, on_delete=models.CASCADE, related_name='depreciation_records')
     
     # Depreciation method
-    DEPRECIATION_METHODS = [
-        ('straight_line', 'Straight Line'),
-        ('declining_balance', 'Declining Balance'),
-        ('sum_of_years', 'Sum of Years Digits'),
-        ('units_of_production', 'Units of Production'),
-    ]
-    method = models.CharField(max_length=20, choices=DEPRECIATION_METHODS, default='straight_line')
+    method = models.CharField(
+        max_length=20,
+        choices=DepreciationMethod.choices,
+        default=DepreciationMethod.STRAIGHT_LINE,
+    )
     
     # Financial details
     basis_value = models.DecimalField(max_digits=18, decimal_places=2)
@@ -472,6 +492,9 @@ class AssetDepreciation(TimeStampedModel):
     class Meta:
         ordering = ['asset', 'depreciation_year']
         unique_together = ['asset', 'depreciation_year']
+        indexes = [
+            models.Index(fields=['asset', 'depreciation_year']),
+        ]
     
     def __str__(self):
         return f"{self.asset.asset_number} - Year {self.depreciation_year}"

--- a/home/models.py
+++ b/home/models.py
@@ -8,12 +8,14 @@ from django.db import models
 from django.contrib.auth import get_user_model
 from django.utils import timezone
 from django.core.validators import MinValueValidator, MaxValueValidator
-import uuid
+
+# Shared abstract models for consistency
+from client.models import TimeStampedModel, UUIDModel
 
 User = get_user_model()
 
 
-class UserPreference(models.Model):
+class UserPreference(TimeStampedModel):
     """Simple user preferences for dashboard customization."""
     
     THEME_CHOICES = [
@@ -37,9 +39,7 @@ class UserPreference(models.Model):
     timezone = models.CharField(max_length=50, default='America/Phoenix')
     date_format = models.CharField(max_length=20, default='%Y-%m-%d')
     
-    # Metadata
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    # Metadata handled by TimeStampedModel
     
     class Meta:
         verbose_name = 'User Preference'
@@ -49,7 +49,7 @@ class UserPreference(models.Model):
         return f"{self.user.first_name}'s Preferences"
 
 
-class Announcement(models.Model):
+class Announcement(UUIDModel, TimeStampedModel):
     """Simple company announcements."""
     
     TYPE_CHOICES = [
@@ -65,7 +65,6 @@ class Announcement(models.Model):
         ('high', 'High'),
     ]
     
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     title = models.CharField(max_length=200)
     content = models.TextField()
     announcement_type = models.CharField(max_length=20, choices=TYPE_CHOICES, default='general')
@@ -81,9 +80,7 @@ class Announcement(models.Model):
     show_on_dashboard = models.BooleanField(default=True)
     require_acknowledgment = models.BooleanField(default=False)
     
-    # Metadata
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    # Metadata handled by TimeStampedModel
     
     class Meta:
         ordering = ['-priority', '-publish_date']
@@ -127,10 +124,8 @@ class AnnouncementAcknowledgment(models.Model):
         return f"{self.user.first_name} acknowledged {self.announcement.title}"
 
 
-class QuickAction(models.Model):
+class QuickAction(UUIDModel, TimeStampedModel):
     """Quick action buttons for dashboard."""
-    
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     title = models.CharField(max_length=100)
     description = models.CharField(max_length=200, blank=True)
     url = models.CharField(max_length=500,blank=True,null=True)
@@ -142,9 +137,7 @@ class QuickAction(models.Model):
     # Permissions (simple approach)
     required_permission = models.CharField(max_length=100, blank=True)
     
-    # Metadata
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    # Metadata handled by TimeStampedModel
     
     class Meta:
         ordering = ['sort_order', 'title']
@@ -155,10 +148,9 @@ class QuickAction(models.Model):
         return self.title
 
 
-class DashboardMetric(models.Model):
+class DashboardMetric(UUIDModel, TimeStampedModel):
     """Simple metrics for dashboard display."""
     
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=100)
     description = models.TextField(blank=True)
     value = models.DecimalField(max_digits=15, decimal_places=2, default=0)

--- a/receipts/models.py
+++ b/receipts/models.py
@@ -5,8 +5,11 @@ from decimal import Decimal
 from hr.models import Worker
 from project.models import Project
 
+# Shared abstract base models
+from client.models import TimeStampedModel
 
-class PurchaseType(models.Model):
+
+class PurchaseType(TimeStampedModel):
     """
     Model representing different types of purchases that can be customized per company.
     """
@@ -28,8 +31,7 @@ class PurchaseType(models.Model):
         default=True,
         help_text='Whether this purchase type is currently available for selection'
     )
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    # Timestamps provided by TimeStampedModel
 
     class Meta:
         ordering = ['name']
@@ -40,7 +42,7 @@ class PurchaseType(models.Model):
         return f"{self.name} ({self.code})"
 
 
-class Receipt(models.Model):
+class Receipt(TimeStampedModel):
     """
     Model representing a receipt for expense tracking.
     Updated for Django 5 with modern best practices.
@@ -113,9 +115,7 @@ class Receipt(models.Model):
         help_text='Date when reimbursement was processed'
     )
     
-    # Timestamps
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    # Timestamps provided by TimeStampedModel
 
     class Meta:
         ordering = ['-date_of_purchase', '-created_at']

--- a/schedule/schedule_models.py
+++ b/schedule/schedule_models.py
@@ -17,6 +17,9 @@ from hr.models import Worker
 from project.models import Project
 from material.models import Supplier
 
+# Shared abstract base models
+from client.models import TimeStampedModel
+
 # Import your existing CalendarManager and EventRelationManager
 # (keeping the existing manager code as it's well-designed)
 
@@ -58,7 +61,7 @@ class CalendarManager(models.Manager):
             calendarrelation__object_id=obj.id
         )
 
-class Calendar(models.Model):
+class Calendar(TimeStampedModel):
     """
     Modernized calendar for grouping events with enhanced features
     """
@@ -149,9 +152,7 @@ class Calendar(models.Model):
         help_text='Auto-accept events from trusted sources'
     )
     
-    # System fields
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    # System fields provided by TimeStampedModel
     
     objects = CalendarManager()
 
@@ -205,7 +206,7 @@ class CalendarRelationManager(models.Manager):
             inheritable=inheritable
         )
 
-class CalendarRelation(models.Model):
+class CalendarRelation(TimeStampedModel):
     """
     Modernized calendar relations with enhanced permissions
     """
@@ -242,7 +243,7 @@ class CalendarRelation(models.Model):
         help_text='Send notifications when calendar changes'
     )
     
-    created_at = models.DateTimeField(auto_now_add=True)
+    # Timestamp handled by TimeStampedModel
     
     objects = CalendarRelationManager()
 
@@ -281,7 +282,7 @@ class EventManager(models.Manager):
             models.Q(creator=worker)
         ).distinct()
 
-class Event(models.Model):
+class Event(TimeStampedModel):
     """
     Modernized event model with enhanced features
     """
@@ -517,8 +518,7 @@ class Event(models.Model):
         verbose_name=_("creator"),
         related_name='created_events'
     )
-    created_at = models.DateTimeField(_("created on"), auto_now_add=True)
-    updated_at = models.DateTimeField(_("updated on"), auto_now=True)
+    # Timestamps provided by TimeStampedModel
     
     # Integration fields
     external_id = models.CharField(
@@ -702,7 +702,7 @@ class EventRelationManager(models.Manager):
             content_object=content_object
         )
 
-class EventRelation(models.Model):
+class EventRelation(TimeStampedModel):
     """
     Enhanced event relations with additional metadata
     """
@@ -754,9 +754,7 @@ class EventRelation(models.Model):
         help_text='Send notifications to this participant'
     )
     
-    # System fields
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    # System fields handled by TimeStampedModel
     
     objects = EventRelationManager()
 
@@ -771,7 +769,7 @@ class EventRelation(models.Model):
     def __str__(self):
         return f'{self.event.title}({self.distinction})-{self.content_object}'
 
-class Occurrence(models.Model):
+class Occurrence(TimeStampedModel):
     """
     Modernized occurrence model for recurring events
     """
@@ -796,9 +794,7 @@ class Occurrence(models.Model):
         help_text='Override status for this specific occurrence'
     )
     
-    # System fields
-    created_at = models.DateTimeField(_("created on"), auto_now_add=True)
-    updated_at = models.DateTimeField(_("updated on"), auto_now=True)
+    # System fields handled by TimeStampedModel
 
     class Meta:
         verbose_name = _("occurrence")

--- a/timecard/models.py
+++ b/timecard/models.py
@@ -11,7 +11,10 @@ from django.core.validators import MinValueValidator, MaxValueValidator
 from hr.models import Worker
 from project.models import Project
 
-class TimesheetPeriod(models.Model):
+# Shared abstract models
+from client.models import TimeStampedModel
+
+class TimesheetPeriod(TimeStampedModel):
     """
     Represents a payroll period for grouping timecards
     """
@@ -37,8 +40,7 @@ class TimesheetPeriod(models.Model):
     due_date = models.DateField(null=True, blank=True, help_text='Timesheet submission deadline')
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default='open')
     is_active = models.BooleanField(default=True)
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    # Timestamps handled by TimeStampedModel
 
     class Meta:
         ordering = ['-start_date']
@@ -87,7 +89,7 @@ class TimeCardManager(models.Manager):
             date__lte=week_end
         )
 
-class TimeCard(models.Model):
+class TimeCard(TimeStampedModel):
     """
     Modernized timecard model with better validation and calculations
     """
@@ -203,9 +205,7 @@ class TimeCard(models.Model):
         help_text='Photo from work site'
     )
     
-    # System fields
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    # System fields handled by TimeStampedModel
     
     objects = TimeCardManager()
 
@@ -415,7 +415,7 @@ class TimeCardAttachment(models.Model):
     def __str__(self):
         return f"{self.timecard} - {self.description or 'Attachment'}"
 
-class TimesheetSummary(models.Model):
+class TimesheetSummary(TimeStampedModel):
     """
     Weekly/period summary for worker timesheets
     """
@@ -447,8 +447,7 @@ class TimesheetSummary(models.Model):
     submitted_at = models.DateTimeField(null=True, blank=True)
     approved_at = models.DateTimeField(null=True, blank=True)
     
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    # Timestamps handled by TimeStampedModel
 
     class Meta:
         unique_together = ['worker', 'period']

--- a/todo/models.py
+++ b/todo/models.py
@@ -11,6 +11,9 @@ from django_extensions.db.fields import AutoSlugField
 from decimal import Decimal
 from datetime import date, datetime, timedelta
 
+# Shared abstract base models
+from client.models import TimeStampedModel
+
 from hr.models import JobPosition, Worker
 from project.models import ScopeOfWork, Project
 
@@ -30,7 +33,7 @@ class TaskListManager(models.Manager):
             is_active=True
         ).distinct()
 
-class TaskList(models.Model):
+class TaskList(TimeStampedModel):
     """
     Modernized task list with enhanced categorization and workflow
     """
@@ -166,9 +169,7 @@ class TaskList(models.Model):
         help_text='Current owner/manager of this task list'
     )
 
-    # System fields
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
+    # System fields provided by TimeStampedModel
 
     objects = TaskListManager()
 
@@ -310,7 +311,7 @@ class TaskManager(models.Manager):
         """Get tasks for a specific group"""
         return self.filter(task_list__group=group)
 
-class Task(models.Model):
+class Task(TimeStampedModel):
     """
     Modernized task model with enhanced tracking and workflow
     """
@@ -492,8 +493,7 @@ class Task(models.Model):
         help_text='Actual hours spent on this task'
     )
 
-    # System fields
-    updated_at = models.DateTimeField(auto_now=True)
+    # System fields provided by TimeStampedModel
 
     objects = TaskManager()
 
@@ -664,7 +664,7 @@ class Task(models.Model):
         
         return new_task
 
-class Comment(models.Model):
+class Comment(TimeStampedModel):
     """
     Enhanced comment model with better tracking and features
     """
@@ -704,7 +704,6 @@ class Comment(models.Model):
         default=timezone.now,
         help_text='When this comment was posted'
     )
-    updated_at = models.DateTimeField(auto_now=True)
     
     # Features
     is_private = models.BooleanField(
@@ -774,7 +773,7 @@ class TaskAttachment(models.Model):
     def __str__(self):
         return f"{self.task.title} - {self.description or 'Attachment'}"
 
-class TaskTemplate(models.Model):
+class TaskTemplate(TimeStampedModel):
     """
     Reusable task templates for common workflows
     """
@@ -799,7 +798,6 @@ class TaskTemplate(models.Model):
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE
     )
-    created_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
         return self.name

--- a/wip/models.py
+++ b/wip/models.py
@@ -1,1 +1,42 @@
 from django.db import models
+
+from client.models import TimeStampedModel, UUIDModel
+from project.models import Project
+from hr.models import Worker
+
+
+class WIPItem(UUIDModel, TimeStampedModel):
+    """Generic work-in-progress tracker."""
+
+    STATUS_CHOICES = [
+        ("pending", "Pending"),
+        ("in_progress", "In Progress"),
+        ("blocked", "Blocked"),
+        ("complete", "Complete"),
+    ]
+
+    project = models.ForeignKey(
+        Project,
+        on_delete=models.CASCADE,
+        related_name="wip_items",
+        null=True,
+        blank=True,
+    )
+    description = models.CharField(max_length=200)
+    assigned_to = models.ForeignKey(
+        Worker,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="wip_items",
+    )
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="pending")
+    progress_percent = models.PositiveIntegerField(default=0)
+    estimated_completion = models.DateField(null=True, blank=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return f"{self.project}: {self.description}" if self.project else self.description
+


### PR DESCRIPTION
## Summary
- use `TimeStampedModel` and `UUIDModel` from `client` in more apps
- remove duplicate timestamp fields
- add a simple WIP tracker model
- modernize asset models with UUIDs and enumeration types

## Testing
- `python -m py_compile home/models.py receipts/models.py timecard/models.py todo/models.py schedule/schedule_models.py wip/models.py asset/models.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6847e3a93c388332aeecd261e7b9ce64