### PR TITLE
Fix stray Unicode newline in asset models

### DIFF
--- a/asset/models.py
+++ b/asset/models.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.urls import reverse
 from django.core.validators import MinValueValidator, MaxValueValidator
 from decimal import Decimal
-from datetime import date, timedelta␊
+from datetime import date, timedelta
 from django.utils.translation import gettext_lazy as _
 
 # Import from your modernized apps


### PR DESCRIPTION
## Summary
- remove an accidental `U+240A` newline symbol in `asset/models.py`

## Testing
- `python -m py_compile asset/models.py`
- `python manage.py check`
- `python manage.py test` *(fails: settings misconfigured)*

------
https://chatgpt.com/codex/tasks/task_e_684f48ba68f883328ced61cb7995c8c1