### PR TITLE
Fix asset assignment meta and rename depreciation model

### DIFF
--- a/asset/models.py
+++ b/asset/models.py
@@ -454,15 +454,15 @@ class AssetAssignment(TimeStampedModel):
     is_active = models.BooleanField(default=True)
     
     class Meta:
-        ordering = ['-performed_date']
+        ordering = ['-start_date']
         indexes = [
-            models.Index(fields=['asset', 'performed_date']),
+            models.Index(fields=['asset', 'start_date']),
         ]
     
     def __str__(self):
         return f"{self.asset.asset_number} assigned on {self.start_date}"
 
-class AssetAssignment(UUIDModel, TimeStampedModel):
+class AssetDepreciation(UUIDModel, TimeStampedModel):
     """Track depreciation schedules for assets"""
     asset = models.ForeignKey(Asset, on_delete=models.CASCADE, related_name='depreciation_records')
     


### PR DESCRIPTION
## Summary
- correct AssetAssignment Meta options
- rename misplaced AssetAssignment model to AssetDepreciation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `python manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684f52f3fbd883329e0e5b5a652ed2c7