### PR TITLE
Add templates for material app

### DIFF
--- a/material/models.py
+++ b/material/models.py
@@ -112,7 +112,7 @@ class Supplier(UUIDModel, TimeStampedModel):
         return self.company_name
     
     def get_absolute_url(self):
-        return reverse('supplier-detail', args=[str(self.id)])
+        return reverse('material:supplier-detail', args=[str(self.id)])
     
     @property
     def primary_address(self):
@@ -396,7 +396,7 @@ class Product(UUIDModel, TimeStampedModel):
         return f"{self.sku} - {self.name}"
     
     def get_absolute_url(self):
-        return reverse('product-detail', args=[str(self.id)])
+        return reverse('material:product-detail', args=[str(self.id)])
     
     # Dynamic choice methods
     def get_available_product_types(self):

--- a/material/templates/material/category_confirm_delete.html
+++ b/material/templates/material/category_confirm_delete.html
@@ -1,0 +1,20 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Delete Category</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:category-list' %}">Product Categories</a></li>
+<li class="breadcrumb-item active">Delete</li>
+{% endblock %}
+{% block content %}
+<form method="post">
+  {% csrf_token %}
+  <div class="card shadow mb-4">
+    <div class="card-body">
+      <p>Are you sure you want to delete {{ object.name }}?</p>
+      <div class="text-end">
+        <button type="submit" class="btn btn-danger">Delete</button>
+        <a href="{% url 'material:category-detail' object.pk %}" class="btn btn-secondary">Cancel</a>
+      </div>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/material/templates/material/category_detail.html
+++ b/material/templates/material/category_detail.html
@@ -1,0 +1,20 @@
+{% extends "home/base.html" %}
+{% block title %}<title>{{ category.name }}</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:category-list' %}">Product Categories</a></li>
+<li class="breadcrumb-item active">{{ category.name }}</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header py-3 d-flex justify-content-between">
+    <h6 class="m-0 font-weight-bold text-primary">{{ category.name }}</h6>
+    <div>
+      <a href="{% url 'material:category-update' category.pk %}" class="btn btn-sm btn-secondary"><i class="fas fa-edit"></i></a>
+      <a href="{% url 'material:category-delete' category.pk %}" class="btn btn-sm btn-danger"><i class="fas fa-trash"></i></a>
+    </div>
+  </div>
+  <div class="card-body">
+    <p>{{ category.description }}</p>
+  </div>
+</div>
+{% endblock %}

--- a/material/templates/material/category_form.html
+++ b/material/templates/material/category_form.html
@@ -1,0 +1,28 @@
+{% extends "home/base.html" %}
+{% block title %}<title>{% if form.instance.pk %}Edit Category{% else %}Add Category{% endif %}</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:category-list' %}">Product Categories</a></li>
+<li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Create{% endif %}</li>
+{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-8">
+    <div class="card shadow">
+      <div class="card-header py-3">
+        <h6 class="m-0 font-weight-bold text-primary">
+          {% if form.instance.pk %}<i class="fas fa-edit"></i> Edit Category{% else %}<i class="fas fa-plus"></i> Add Category{% endif %}
+        </h6>
+      </div>
+      <div class="card-body">
+        <form method="post" enctype="multipart/form-data">
+          {% csrf_token %}
+          {{ form.as_p }}
+          <div class="text-end">
+            <button type="submit" class="btn btn-primary">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/material/templates/material/category_list.html
+++ b/material/templates/material/category_list.html
@@ -1,0 +1,33 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Product Categories</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item active">Product Categories</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header py-3 d-flex justify-content-between">
+    <h6 class="m-0 font-weight-bold text-primary">Categories</h6>
+    <a href="{% url 'material:category-create' %}" class="btn btn-primary btn-sm">
+      <i class="fas fa-plus"></i> Add Category
+    </a>
+  </div>
+  <div class="card-body p-0">
+    <table class="table table-striped mb-0">
+      <thead>
+        <tr>
+          <th>Name</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for category in categories %}
+        <tr>
+          <td><a href="{% url 'material:category-detail' category.pk %}">{{ category.name }}</a></td>
+        </tr>
+        {% empty %}
+        <tr><td class="text-center">No categories found.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/material/templates/material/manufacturer_confirm_delete.html
+++ b/material/templates/material/manufacturer_confirm_delete.html
@@ -1,0 +1,20 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Delete Manufacturer</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:manufacturer-list' %}">Manufacturers</a></li>
+<li class="breadcrumb-item active">Delete</li>
+{% endblock %}
+{% block content %}
+<form method="post">
+  {% csrf_token %}
+  <div class="card shadow mb-4">
+    <div class="card-body">
+      <p>Are you sure you want to delete {{ object.name }}?</p>
+      <div class="text-end">
+        <button type="submit" class="btn btn-danger">Delete</button>
+        <a href="{% url 'material:manufacturer-detail' object.pk %}" class="btn btn-secondary">Cancel</a>
+      </div>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/material/templates/material/manufacturer_detail.html
+++ b/material/templates/material/manufacturer_detail.html
@@ -1,0 +1,20 @@
+{% extends "home/base.html" %}
+{% block title %}<title>{{ manufacturer.name }}</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:manufacturer-list' %}">Manufacturers</a></li>
+<li class="breadcrumb-item active">{{ manufacturer.name }}</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header py-3 d-flex justify-content-between">
+    <h6 class="m-0 font-weight-bold text-primary">{{ manufacturer.name }}</h6>
+    <div>
+      <a href="{% url 'material:manufacturer-update' manufacturer.pk %}" class="btn btn-sm btn-secondary"><i class="fas fa-edit"></i></a>
+      <a href="{% url 'material:manufacturer-delete' manufacturer.pk %}" class="btn btn-sm btn-danger"><i class="fas fa-trash"></i></a>
+    </div>
+  </div>
+  <div class="card-body">
+    <p>{{ manufacturer.description }}</p>
+  </div>
+</div>
+{% endblock %}

--- a/material/templates/material/manufacturer_form.html
+++ b/material/templates/material/manufacturer_form.html
@@ -1,0 +1,28 @@
+{% extends "home/base.html" %}
+{% block title %}<title>{% if form.instance.pk %}Edit Manufacturer{% else %}Add Manufacturer{% endif %}</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:manufacturer-list' %}">Manufacturers</a></li>
+<li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Create{% endif %}</li>
+{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-8">
+    <div class="card shadow">
+      <div class="card-header py-3">
+        <h6 class="m-0 font-weight-bold text-primary">
+          {% if form.instance.pk %}<i class="fas fa-edit"></i> Edit Manufacturer{% else %}<i class="fas fa-plus"></i> Add Manufacturer{% endif %}
+        </h6>
+      </div>
+      <div class="card-body">
+        <form method="post" enctype="multipart/form-data">
+          {% csrf_token %}
+          {{ form.as_p }}
+          <div class="text-end">
+            <button type="submit" class="btn btn-primary">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/material/templates/material/manufacturer_list.html
+++ b/material/templates/material/manufacturer_list.html
@@ -1,0 +1,31 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Manufacturers</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item active">Manufacturers</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header py-3 d-flex justify-content-between">
+    <h6 class="m-0 font-weight-bold text-primary">Manufacturers</h6>
+    <a href="{% url 'material:manufacturer-create' %}" class="btn btn-primary btn-sm">
+      <i class="fas fa-plus"></i> Add Manufacturer
+    </a>
+  </div>
+  <div class="card-body p-0">
+    <table class="table table-striped mb-0">
+      <thead>
+        <tr><th>Name</th></tr>
+      </thead>
+      <tbody>
+        {% for manufacturer in manufacturers %}
+        <tr>
+          <td><a href="{% url 'material:manufacturer-detail' manufacturer.pk %}">{{ manufacturer.name }}</a></td>
+        </tr>
+        {% empty %}
+        <tr><td class="text-center">No manufacturers found.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/material/templates/material/product_confirm_delete.html
+++ b/material/templates/material/product_confirm_delete.html
@@ -1,0 +1,20 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Delete Product</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:product-list' %}">Products</a></li>
+<li class="breadcrumb-item active">Delete</li>
+{% endblock %}
+{% block content %}
+<form method="post">
+  {% csrf_token %}
+  <div class="card shadow mb-4">
+    <div class="card-body">
+      <p>Are you sure you want to delete {{ object.name }}?</p>
+      <div class="text-end">
+        <button type="submit" class="btn btn-danger">Delete</button>
+        <a href="{% url 'material:product-detail' object.pk %}" class="btn btn-secondary">Cancel</a>
+      </div>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/material/templates/material/product_detail.html
+++ b/material/templates/material/product_detail.html
@@ -1,0 +1,22 @@
+{% extends "home/base.html" %}
+{% block title %}<title>{{ product.name }}</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:product-list' %}">Products</a></li>
+<li class="breadcrumb-item active">{{ product.name }}</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header py-3 d-flex justify-content-between">
+    <h6 class="m-0 font-weight-bold text-primary">{{ product.name }}</h6>
+    <div>
+      <a href="{% url 'material:product-update' product.pk %}" class="btn btn-sm btn-secondary"><i class="fas fa-edit"></i></a>
+      <a href="{% url 'material:product-delete' product.pk %}" class="btn btn-sm btn-danger"><i class="fas fa-trash"></i></a>
+    </div>
+  </div>
+  <div class="card-body">
+    <p><strong>SKU:</strong> {{ product.sku }}</p>
+    <p><strong>Category:</strong> {{ product.category }}</p>
+    <p><strong>Description:</strong> {{ product.description }}</p>
+  </div>
+</div>
+{% endblock %}

--- a/material/templates/material/product_form.html
+++ b/material/templates/material/product_form.html
@@ -1,0 +1,28 @@
+{% extends "home/base.html" %}
+{% block title %}<title>{% if form.instance.pk %}Edit Product{% else %}Add Product{% endif %}</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:product-list' %}">Products</a></li>
+<li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Create{% endif %}</li>
+{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-8">
+    <div class="card shadow">
+      <div class="card-header py-3">
+        <h6 class="m-0 font-weight-bold text-primary">
+          {% if form.instance.pk %}<i class="fas fa-edit"></i> Edit Product{% else %}<i class="fas fa-plus"></i> Add Product{% endif %}
+        </h6>
+      </div>
+      <div class="card-body">
+        <form method="post" enctype="multipart/form-data">
+          {% csrf_token %}
+          {{ form.as_p }}
+          <div class="text-end">
+            <button type="submit" class="btn btn-primary">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/material/templates/material/product_list.html
+++ b/material/templates/material/product_list.html
@@ -1,0 +1,35 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Products</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item active">Products</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header py-3 d-flex justify-content-between">
+    <h6 class="m-0 font-weight-bold text-primary">Products</h6>
+    <a href="{% url 'material:product-create' %}" class="btn btn-primary btn-sm">
+      <i class="fas fa-plus"></i> Add Product
+    </a>
+  </div>
+  <div class="card-body p-0">
+    <table class="table table-striped mb-0">
+      <thead>
+        <tr>
+          <th>SKU</th>
+          <th>Name</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for product in products %}
+        <tr>
+          <td><a href="{% url 'material:product-detail' product.pk %}">{{ product.sku }}</a></td>
+          <td>{{ product.name }}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="2" class="text-center">No products found.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/material/templates/material/supplier_confirm_delete.html
+++ b/material/templates/material/supplier_confirm_delete.html
@@ -1,0 +1,20 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Delete Supplier</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:supplier-list' %}">Suppliers</a></li>
+<li class="breadcrumb-item active">Delete</li>
+{% endblock %}
+{% block content %}
+<form method="post">
+  {% csrf_token %}
+  <div class="card shadow mb-4">
+    <div class="card-body">
+      <p>Are you sure you want to delete {{ object.company_name }}?</p>
+      <div class="text-end">
+        <button type="submit" class="btn btn-danger">Delete</button>
+        <a href="{{ object.get_absolute_url }}" class="btn btn-secondary">Cancel</a>
+      </div>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/material/templates/material/supplier_detail.html
+++ b/material/templates/material/supplier_detail.html
@@ -1,0 +1,23 @@
+{% extends "home/base.html" %}
+{% block title %}<title>{{ supplier.company_name }}</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:supplier-list' %}">Suppliers</a></li>
+<li class="breadcrumb-item active">{{ supplier.company_name }}</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header py-3 d-flex justify-content-between">
+    <h6 class="m-0 font-weight-bold text-primary">{{ supplier.company_name }}</h6>
+    <div>
+      <a href="{% url 'material:supplier-update' supplier.pk %}" class="btn btn-sm btn-secondary"><i class="fas fa-edit"></i></a>
+      <a href="{% url 'material:supplier-delete' supplier.pk %}" class="btn btn-sm btn-danger"><i class="fas fa-trash"></i></a>
+    </div>
+  </div>
+  <div class="card-body">
+    <p><strong>Type:</strong> {{ supplier.get_supplier_type_display|default:supplier.supplier_type }}</p>
+    <p><strong>Email:</strong> {{ supplier.primary_email }}</p>
+    <p><strong>Phone:</strong> {{ supplier.primary_phone }}</p>
+    <p><strong>Website:</strong> <a href="{{ supplier.website }}">{{ supplier.website }}</a></p>
+  </div>
+</div>
+{% endblock %}

--- a/material/templates/material/supplier_form.html
+++ b/material/templates/material/supplier_form.html
@@ -1,0 +1,28 @@
+{% extends "home/base.html" %}
+{% block title %}<title>{% if form.instance.pk %}Edit Supplier{% else %}Add Supplier{% endif %}</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:supplier-list' %}">Suppliers</a></li>
+<li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Create{% endif %}</li>
+{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-8">
+    <div class="card shadow">
+      <div class="card-header py-3">
+        <h6 class="m-0 font-weight-bold text-primary">
+          {% if form.instance.pk %}<i class="fas fa-edit"></i> Edit Supplier{% else %}<i class="fas fa-plus"></i> Add Supplier{% endif %}
+        </h6>
+      </div>
+      <div class="card-body">
+        <form method="post" enctype="multipart/form-data">
+          {% csrf_token %}
+          {{ form.as_p }}
+          <div class="text-end">
+            <button type="submit" class="btn btn-primary">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/material/templates/material/supplier_list.html
+++ b/material/templates/material/supplier_list.html
@@ -1,0 +1,35 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Suppliers</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item active">Suppliers</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header py-3 d-flex justify-content-between">
+    <h6 class="m-0 font-weight-bold text-primary">Suppliers</h6>
+    <a href="{% url 'material:supplier-create' %}" class="btn btn-primary btn-sm">
+      <i class="fas fa-plus"></i> Add Supplier
+    </a>
+  </div>
+  <div class="card-body p-0">
+    <table class="table table-striped mb-0">
+      <thead>
+        <tr>
+          <th>Company</th>
+          <th>Type</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for supplier in suppliers %}
+        <tr>
+          <td><a href="{{ supplier.get_absolute_url }}">{{ supplier.company_name }}</a></td>
+          <td>{{ supplier.get_supplier_type_display|default:supplier.supplier_type }}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="2" class="text-center">No suppliers found.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/material/templates/material/transaction_confirm_delete.html
+++ b/material/templates/material/transaction_confirm_delete.html
@@ -1,0 +1,20 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Delete Transaction</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:transaction-list' %}">Inventory Transactions</a></li>
+<li class="breadcrumb-item active">Delete</li>
+{% endblock %}
+{% block content %}
+<form method="post">
+  {% csrf_token %}
+  <div class="card shadow mb-4">
+    <div class="card-body">
+      <p>Are you sure you want to delete this transaction?</p>
+      <div class="text-end">
+        <button type="submit" class="btn btn-danger">Delete</button>
+        <a href="{% url 'material:transaction-detail' object.pk %}" class="btn btn-secondary">Cancel</a>
+      </div>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/material/templates/material/transaction_detail.html
+++ b/material/templates/material/transaction_detail.html
@@ -1,0 +1,22 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Transaction</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:transaction-list' %}">Inventory Transactions</a></li>
+<li class="breadcrumb-item active">Detail</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header py-3 d-flex justify-content-between">
+    <h6 class="m-0 font-weight-bold text-primary">Transaction Detail</h6>
+    <div>
+      <a href="{% url 'material:transaction-update' transaction.pk %}" class="btn btn-sm btn-secondary"><i class="fas fa-edit"></i></a>
+      <a href="{% url 'material:transaction-delete' transaction.pk %}" class="btn btn-sm btn-danger"><i class="fas fa-trash"></i></a>
+    </div>
+  </div>
+  <div class="card-body">
+    <p><strong>Product:</strong> {{ transaction.product }}</p>
+    <p><strong>Type:</strong> {{ transaction.get_transaction_type_display|default:transaction.transaction_type }}</p>
+    <p><strong>Quantity:</strong> {{ transaction.quantity }}</p>
+  </div>
+</div>
+{% endblock %}

--- a/material/templates/material/transaction_form.html
+++ b/material/templates/material/transaction_form.html
@@ -1,0 +1,28 @@
+{% extends "home/base.html" %}
+{% block title %}<title>{% if form.instance.pk %}Edit Transaction{% else %}Add Transaction{% endif %}</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'material:transaction-list' %}">Inventory Transactions</a></li>
+<li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Create{% endif %}</li>
+{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-8">
+    <div class="card shadow">
+      <div class="card-header py-3">
+        <h6 class="m-0 font-weight-bold text-primary">
+          {% if form.instance.pk %}<i class="fas fa-edit"></i> Edit Transaction{% else %}<i class="fas fa-plus"></i> Add Transaction{% endif %}
+        </h6>
+      </div>
+      <div class="card-body">
+        <form method="post" enctype="multipart/form-data">
+          {% csrf_token %}
+          {{ form.as_p }}
+          <div class="text-end">
+            <button type="submit" class="btn btn-primary">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/material/templates/material/transaction_list.html
+++ b/material/templates/material/transaction_list.html
@@ -1,0 +1,37 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Inventory Transactions</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item active">Inventory Transactions</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header py-3 d-flex justify-content-between">
+    <h6 class="m-0 font-weight-bold text-primary">Transactions</h6>
+    <a href="{% url 'material:transaction-create' %}" class="btn btn-primary btn-sm">
+      <i class="fas fa-plus"></i> Add Transaction
+    </a>
+  </div>
+  <div class="card-body p-0">
+    <table class="table table-striped mb-0">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Product</th>
+          <th>Type</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for transaction in transactions %}
+        <tr>
+          <td><a href="{% url 'material:transaction-detail' transaction.pk %}">{{ transaction.created_at|date:"SHORT_DATE_FORMAT" }}</a></td>
+          <td>{{ transaction.product }}</td>
+          <td>{{ transaction.get_transaction_type_display|default:transaction.transaction_type }}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="3" class="text-center">No transactions found.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add bootstrap-based templates for the material app
- update `get_absolute_url` methods to use namespaced URLs

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError and ImproperlyConfigured)*

------
https://chatgpt.com/codex/tasks/task_e_684f808061888332933b2deadb6f7e10