### PR TITLE
Add modern receipt views

### DIFF
--- a/receipts/templates/receipts/purchase_type_confirm_delete.html
+++ b/receipts/templates/receipts/purchase_type_confirm_delete.html
@@ -1,0 +1,24 @@
+{% extends "home/base.html" %}
+
+{% block title %}<title>Delete Purchase Type</title>{% endblock %}
+
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'receipts:purchase-type-list' %}">Purchase Types</a></li>
+<li class="breadcrumb-item active">Delete</li>
+{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="card border-danger">
+        <div class="card-header bg-danger text-white">Confirm Delete</div>
+        <div class="card-body">
+            <p>Are you sure you want to delete <strong>{{ object.name }}</strong>?</p>
+            <form method="post">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-danger">Confirm</button>
+                <a href="{% url 'receipts:purchase-type-detail' object.pk %}" class="btn btn-secondary">Cancel</a>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/receipts/templates/receipts/purchase_type_detail.html
+++ b/receipts/templates/receipts/purchase_type_detail.html
@@ -1,0 +1,28 @@
+{% extends "home/base.html" %}
+
+{% block title %}<title>{{ purchase_type.name }}</title>{% endblock %}
+
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'receipts:purchase-type-list' %}">Purchase Types</a></li>
+<li class="breadcrumb-item active">{{ purchase_type.name }}</li>
+{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="card mb-3">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h5 class="mb-0">{{ purchase_type.name }}</h5>
+            <div>
+                <a href="{% url 'receipts:purchase-type-update' purchase_type.pk %}" class="btn btn-sm btn-secondary">Edit</a>
+                <a href="{% url 'receipts:purchase-type-delete' purchase_type.pk %}" class="btn btn-sm btn-danger">Delete</a>
+            </div>
+        </div>
+        <div class="card-body">
+            <p><strong>Code:</strong> {{ purchase_type.code }}</p>
+            <p><strong>Description:</strong> {{ purchase_type.description }}</p>
+            <p><strong>Active:</strong> {{ purchase_type.is_active }}</p>
+        </div>
+    </div>
+    <a href="{% url 'receipts:purchase-type-list' %}" class="btn btn-secondary">Back to list</a>
+</div>
+{% endblock %}

--- a/receipts/templates/receipts/purchase_type_form.html
+++ b/receipts/templates/receipts/purchase_type_form.html
@@ -1,0 +1,30 @@
+{% extends "home/base.html" %}
+
+{% block title %}
+<title>{% if form.instance.pk %}Edit Purchase Type{% else %}New Purchase Type{% endif %}</title>
+{% endblock %}
+
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'receipts:purchase-type-list' %}">Purchase Types</a></li>
+<li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Create{% endif %}</li>
+{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="card">
+        <div class="card-header">
+            <h5 class="mb-0">{% if form.instance.pk %}Edit Purchase Type{% else %}New Purchase Type{% endif %}</h5>
+        </div>
+        <div class="card-body">
+            <form method="post">
+                {% csrf_token %}
+                {{ form.as_p }}
+                <div class="mt-3">
+                    <button type="submit" class="btn btn-primary">Save</button>
+                    <a href="{% url 'receipts:purchase-type-list' %}" class="btn btn-secondary">Cancel</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/receipts/templates/receipts/purchase_type_list.html
+++ b/receipts/templates/receipts/purchase_type_list.html
@@ -1,0 +1,43 @@
+{% extends "home/base.html" %}
+{% load static %}
+
+{% block title %}<title>Purchase Types</title>{% endblock %}
+
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'receipts:list' %}">Receipts</a></li>
+<li class="breadcrumb-item active">Purchase Types</li>
+{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="h3 mb-0">Purchase Types</h1>
+        <a href="{% url 'receipts:purchase-type-create' %}" class="btn btn-primary">
+            <i class="fas fa-plus"></i> New Type
+        </a>
+    </div>
+
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Code</th>
+                <th>Description</th>
+                <th>Active</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for pt in purchase_types %}
+            <tr>
+                <td><a href="{% url 'receipts:purchase-type-detail' pt.pk %}">{{ pt.name }}</a></td>
+                <td>{{ pt.code }}</td>
+                <td>{{ pt.description }}</td>
+                <td>{{ pt.is_active }}</td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="4" class="text-center">No purchase types found.</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/receipts/templates/receipts/receipt_confirm_delete.html
+++ b/receipts/templates/receipts/receipt_confirm_delete.html
@@ -1,0 +1,24 @@
+{% extends "home/base.html" %}
+
+{% block title %}<title>Delete Receipt</title>{% endblock %}
+
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'receipts:list' %}">Receipts</a></li>
+<li class="breadcrumb-item active">Delete</li>
+{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="card border-danger">
+        <div class="card-header bg-danger text-white">Confirm Delete</div>
+        <div class="card-body">
+            <p>Are you sure you want to delete this receipt from <strong>{{ object.company_name }}</strong> on {{ object.date_of_purchase }}?</p>
+            <form method="post">
+                {% csrf_token %}
+                <button type="submit" class="btn btn-danger">Confirm</button>
+                <a href="{% url 'receipts:detail' object.pk %}" class="btn btn-secondary">Cancel</a>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/receipts/templates/receipts/receipt_detail.html
+++ b/receipts/templates/receipts/receipt_detail.html
@@ -1,0 +1,53 @@
+{% extends "home/base.html" %}
+
+{% block title %}<title>Receipt {{ receipt.id }}</title>{% endblock %}
+
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'receipts:list' %}">Receipts</a></li>
+<li class="breadcrumb-item active">Detail</li>
+{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="card mb-3">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h5 class="mb-0">Receipt from {{ receipt.company_name }}</h5>
+            <div>
+                <a href="{% url 'receipts:update' receipt.pk %}" class="btn btn-sm btn-secondary">Edit</a>
+                <a href="{% url 'receipts:delete' receipt.pk %}" class="btn btn-sm btn-danger">Delete</a>
+            </div>
+        </div>
+        <div class="card-body">
+            <dl class="row">
+                <dt class="col-sm-3">Date</dt>
+                <dd class="col-sm-9">{{ receipt.date_of_purchase }}</dd>
+
+                <dt class="col-sm-3">Project</dt>
+                <dd class="col-sm-9">{{ receipt.project|default:"-" }}</dd>
+
+                <dt class="col-sm-3">Worker</dt>
+                <dd class="col-sm-9">{{ receipt.worker|default:"-" }}</dd>
+
+                <dt class="col-sm-3">Type</dt>
+                <dd class="col-sm-9">{{ receipt.purchase_type }}</dd>
+
+                <dt class="col-sm-3">Amount</dt>
+                <dd class="col-sm-9">{{ receipt.total_amount }} {{ receipt.currency }}</dd>
+
+                <dt class="col-sm-3">Description</dt>
+                <dd class="col-sm-9">{{ receipt.description|linebreaksbr }}</dd>
+
+                <dt class="col-sm-3">Notes</dt>
+                <dd class="col-sm-9">{{ receipt.notes|linebreaksbr }}</dd>
+
+                <dt class="col-sm-3">Reimbursed</dt>
+                <dd class="col-sm-9">{{ receipt.is_reimbursed }}{% if receipt.reimbursement_date %} on {{ receipt.reimbursement_date }}{% endif %}</dd>
+            </dl>
+            {% if receipt.receipt_image %}
+            <img src="{{ receipt.receipt_image.url }}" class="img-fluid" alt="Receipt image">
+            {% endif %}
+        </div>
+    </div>
+    <a href="{% url 'receipts:list' %}" class="btn btn-secondary">Back to list</a>
+</div>
+{% endblock %}

--- a/receipts/templates/receipts/receipt_form.html
+++ b/receipts/templates/receipts/receipt_form.html
@@ -1,0 +1,30 @@
+{% extends "home/base.html" %}
+
+{% block title %}
+<title>{% if form.instance.pk %}Edit Receipt{% else %}New Receipt{% endif %}</title>
+{% endblock %}
+
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'receipts:list' %}">Receipts</a></li>
+<li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Create{% endif %}</li>
+{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="card">
+        <div class="card-header">
+            <h5 class="mb-0">{% if form.instance.pk %}Edit Receipt{% else %}New Receipt{% endif %}</h5>
+        </div>
+        <div class="card-body">
+            <form method="post" enctype="multipart/form-data">
+                {% csrf_token %}
+                {{ form.as_p }}
+                <div class="mt-3">
+                    <button type="submit" class="btn btn-primary">Save</button>
+                    <a href="{% url 'receipts:list' %}" class="btn btn-secondary">Cancel</a>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/receipts/templates/receipts/receipt_list.html
+++ b/receipts/templates/receipts/receipt_list.html
@@ -1,0 +1,76 @@
+{% extends "home/base.html" %}
+{% load static %}
+
+{% block title %}<title>Receipts</title>{% endblock %}
+
+{% block breadcrumb %}
+<li class="breadcrumb-item active">Receipts</li>
+{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="h3 mb-0">Receipts</h1>
+        <a href="{% url 'receipts:create' %}" class="btn btn-primary">
+            <i class="fas fa-plus"></i> New Receipt
+        </a>
+    </div>
+
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Company</th>
+                <th>Project</th>
+                <th>Worker</th>
+                <th>Type</th>
+                <th class="text-end">Amount</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for receipt in receipts %}
+            <tr>
+                <td>{{ receipt.date_of_purchase }}</td>
+                <td>
+                    <a href="{% url 'receipts:detail' receipt.pk %}">{{ receipt.company_name }}</a>
+                </td>
+                <td>{{ receipt.project }}</td>
+                <td>{{ receipt.worker }}</td>
+                <td>{{ receipt.purchase_type }}</td>
+                <td class="text-end">{{ receipt.total_amount }} {{ receipt.currency }}</td>
+            </tr>
+            {% empty %}
+            <tr><td colspan="6" class="text-center">No receipts found.</td></tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    {% if is_paginated %}
+    <nav aria-label="Receipt pagination">
+        <ul class="pagination">
+            {% if page_obj.has_previous %}
+                <li class="page-item">
+                    <a class="page-link" href="?page={{ page_obj.previous_page_number }}">Previous</a>
+                </li>
+            {% else %}
+                <li class="page-item disabled"><span class="page-link">Previous</span></li>
+            {% endif %}
+            {% for num in paginator.page_range %}
+                {% if page_obj.number == num %}
+                    <li class="page-item active"><span class="page-link">{{ num }}</span></li>
+                {% else %}
+                    <li class="page-item"><a class="page-link" href="?page={{ num }}">{{ num }}</a></li>
+                {% endif %}
+            {% endfor %}
+            {% if page_obj.has_next %}
+                <li class="page-item">
+                    <a class="page-link" href="?page={{ page_obj.next_page_number }}">Next</a>
+                </li>
+            {% else %}
+                <li class="page-item disabled"><span class="page-link">Next</span></li>
+            {% endif %}
+        </ul>
+    </nav>
+    {% endif %}
+</div>
+{% endblock %}

--- a/receipts/urls.py
+++ b/receipts/urls.py
@@ -1,0 +1,19 @@
+from django.urls import path
+from . import views
+
+app_name = 'receipts'
+
+urlpatterns = [
+    path('', views.ReceiptListView.as_view(), name='list'),
+    path('create/', views.ReceiptCreateView.as_view(), name='create'),
+    path('<int:pk>/', views.ReceiptDetailView.as_view(), name='detail'),
+    path('<int:pk>/edit/', views.ReceiptUpdateView.as_view(), name='update'),
+    path('<int:pk>/delete/', views.ReceiptDeleteView.as_view(), name='delete'),
+
+    # Purchase type management
+    path('purchase-types/', views.PurchaseTypeListView.as_view(), name='purchase-type-list'),
+    path('purchase-types/create/', views.PurchaseTypeCreateView.as_view(), name='purchase-type-create'),
+    path('purchase-types/<int:pk>/', views.PurchaseTypeDetailView.as_view(), name='purchase-type-detail'),
+    path('purchase-types/<int:pk>/edit/', views.PurchaseTypeUpdateView.as_view(), name='purchase-type-update'),
+    path('purchase-types/<int:pk>/delete/', views.PurchaseTypeDeleteView.as_view(), name='purchase-type-delete'),
+]

--- a/receipts/views.py
+++ b/receipts/views.py
@@ -1,0 +1,87 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.urls import reverse_lazy
+from django.views.generic import (
+    ListView, DetailView, CreateView, UpdateView, DeleteView
+)
+
+from .models import Receipt, PurchaseType
+
+
+class ReceiptListView(LoginRequiredMixin, ListView):
+    model = Receipt
+    template_name = 'receipts/receipt_list.html'
+    context_object_name = 'receipts'
+    paginate_by = 25
+    ordering = ['-date_of_purchase']
+
+    def get_queryset(self):
+        return super().get_queryset().select_related('project', 'worker', 'purchase_type')
+
+
+class ReceiptDetailView(LoginRequiredMixin, DetailView):
+    model = Receipt
+    template_name = 'receipts/receipt_detail.html'
+    context_object_name = 'receipt'
+
+
+class ReceiptCreateView(LoginRequiredMixin, CreateView):
+    model = Receipt
+    fields = [
+        'date_of_purchase', 'company_name', 'project', 'worker',
+        'purchase_type', 'description', 'total_amount', 'currency',
+        'is_tax_deductible', 'receipt_image', 'notes',
+        'is_reimbursed', 'reimbursement_date'
+    ]
+    template_name = 'receipts/receipt_form.html'
+    success_url = reverse_lazy('receipts:list')
+
+
+class ReceiptUpdateView(LoginRequiredMixin, UpdateView):
+    model = Receipt
+    fields = [
+        'date_of_purchase', 'company_name', 'project', 'worker',
+        'purchase_type', 'description', 'total_amount', 'currency',
+        'is_tax_deductible', 'receipt_image', 'notes',
+        'is_reimbursed', 'reimbursement_date'
+    ]
+    template_name = 'receipts/receipt_form.html'
+    success_url = reverse_lazy('receipts:list')
+
+
+class ReceiptDeleteView(LoginRequiredMixin, DeleteView):
+    model = Receipt
+    template_name = 'receipts/receipt_confirm_delete.html'
+    success_url = reverse_lazy('receipts:list')
+
+
+class PurchaseTypeListView(LoginRequiredMixin, ListView):
+    model = PurchaseType
+    template_name = 'receipts/purchase_type_list.html'
+    context_object_name = 'purchase_types'
+    ordering = ['name']
+
+
+class PurchaseTypeCreateView(LoginRequiredMixin, CreateView):
+    model = PurchaseType
+    fields = ['name', 'code', 'description', 'is_active']
+    template_name = 'receipts/purchase_type_form.html'
+    success_url = reverse_lazy('receipts:purchase-type-list')
+
+
+class PurchaseTypeUpdateView(LoginRequiredMixin, UpdateView):
+    model = PurchaseType
+    fields = ['name', 'code', 'description', 'is_active']
+    template_name = 'receipts/purchase_type_form.html'
+    success_url = reverse_lazy('receipts:purchase-type-list')
+
+
+class PurchaseTypeDetailView(LoginRequiredMixin, DetailView):
+    model = PurchaseType
+    template_name = 'receipts/purchase_type_detail.html'
+    context_object_name = 'purchase_type'
+
+
+class PurchaseTypeDeleteView(LoginRequiredMixin, DeleteView):
+    model = PurchaseType
+    template_name = 'receipts/purchase_type_confirm_delete.html'
+    success_url = reverse_lazy('receipts:purchase-type-list')


### PR DESCRIPTION
## Summary
- implement CRUD views for receipts and purchase types
- map routes in `receipts/urls.py`
- add templates for receipts and purchase types

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_684f810deed483328fe940e4ff8ce714