### PR TITLE
Update README with missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a collection of Django applications for managing many a
 
 - Python 3.11+
 - Django 5.2
-- Additional packages listed in `wbee/settings/base.py` (e.g. `django-extensions`, `djangorestframework`, `django-filter`, `django-import-export`, `django-crispy-forms`, `crispy-bootstrap5`, `django-cors-headers`, `dj-database-url`, `python-decouple`, `Pillow`, `easy-thumbnails`, `django-mptt`, `bleach`, `pytest-django`).
+- Additional packages listed in `wbee/settings/base.py` (e.g. `django-extensions`, `djangorestframework`, `django-filter`, `django-import-export`, `django-crispy-forms`, `crispy-bootstrap5`, `django-cors-headers`, `dj-database-url`, `python-decouple`, `Pillow`, `easy-thumbnails`, `django-mptt`, `bleach`, `pytest-django`, `django-grappelli`, `django-filer`, `whitenoise`, `redis`, `qrcode`, `pytz`, `psycopg2-binary`, `sentry-sdk`, `django-storages[boto3]`, `django-debug-toolbar`).
 - A database supported by Django (SQLite is fine for development).
 
 ## Environment Setup
@@ -24,7 +24,9 @@ $ source .venv/bin/activate
 (venv)$ pip install Django==5.2 django-extensions easy-thumbnails django-mptt \
     django-cors-headers djangorestframework django-filter django-import-export \
     django-crispy-forms crispy-bootstrap5 dj-database-url python-decouple \
-    Pillow bleach pytest-django icalendar
+    Pillow bleach pytest-django icalendar django-grappelli django-filer \
+    whitenoise redis qrcode pytz psycopg2-binary sentry-sdk \
+    django-storages[boto3] django-debug-toolbar
 ```
 
 Create a `.env` file (or set environment variables) for secrets and database configuration.  A minimal example:


### PR DESCRIPTION
## Summary
- document additional packages like `django-grappelli` and `django-filer`
- expand example `pip install` command

## Testing
- `python manage.py check`
- `python manage.py test` *(fails: settings.DATABASES is improperly configured)*

------
https://chatgpt.com/codex/tasks/task_e_684fa8c05edc8332a3727d5f92d0bff9