### PR TITLE
Remove wire-specific code

### DIFF
--- a/project/admin.py
+++ b/project/admin.py
@@ -448,7 +448,6 @@ class ProjectAdmin(admin.ModelAdmin):
             costs = obj.calculate_material_costs()
             html = "<table style='font-size: 12px;'>"
             html += f"<tr><td><strong>Devices:</strong></td><td>${costs['device_cost']:,.2f}</td></tr>"
-            html += f"<tr><td><strong>Wire:</strong></td><td>${costs['wire_cost']:,.2f}</td></tr>"
             html += f"<tr><td><strong>Hardware:</strong></td><td>${costs['hardware_cost']:,.2f}</td></tr>"
             html += f"<tr><td><strong>Software:</strong></td><td>${costs['software_cost']:,.2f}</td></tr>"
             html += f"<tr><td><strong>Licenses:</strong></td><td>${costs['license_cost']:,.2f}</td></tr>"

--- a/project/models.py
+++ b/project/models.py
@@ -382,20 +382,18 @@ class Project(UUIDModel, TimeStampedModel):
     def calculate_material_costs(self):
         """Calculate total material costs"""
         device_cost = sum(item.total for item in self.device_items.all())
-        wire_cost = sum(item.total for item in self.wire_items.all())
         hardware_cost = sum(item.total for item in self.hardware_items.all())
         software_cost = sum(item.total for item in self.software_items.all())
         license_cost = sum(item.total for item in self.license_items.all())
         travel_cost = sum(item.total for item in self.travel_items.all())
-        
+
         return {
             'device_cost': device_cost,
-            'wire_cost': wire_cost,
             'hardware_cost': hardware_cost,
             'software_cost': software_cost,
             'license_cost': license_cost,
             'travel_cost': travel_cost,
-            'total_cost': device_cost + wire_cost + hardware_cost + software_cost + license_cost + travel_cost
+            'total_cost': device_cost + hardware_cost + software_cost + license_cost + travel_cost
         }
     
     # Project status management
@@ -519,7 +517,7 @@ class ProjectDevice(TimeStampedModel):
             models.Index(fields=['delivered_date']),
         ]
 
-# Similar enhanced models for Wire, Hardware, Software, License, Travel
+# Similar enhanced models for Hardware, Software, License, and Travel
 # (Following the same pattern as ProjectDevice)
 
 # Project change tracking

--- a/project/urls.py
+++ b/project/urls.py
@@ -71,12 +71,6 @@ urlpatterns = [
     path('devices/<int:pk>/edit/', views.ProjectDeviceUpdateView.as_view(), name='device-edit'),
     path('devices/<int:pk>/delete/', views.ProjectDeviceDeleteView.as_view(), name='device-delete'),
     
-    # Wire Management
-    path('projects/<str:job_number>/wire/', views.ProjectWireListView.as_view(), name='wire-list'),
-    path('projects/<str:job_number>/wire/create/', views.ProjectWireCreateView.as_view(), name='wire-create'),
-    path('wire/<int:pk>/', views.ProjectWireDetailView.as_view(), name='wire-detail'),
-    path('wire/<int:pk>/edit/', views.ProjectWireUpdateView.as_view(), name='wire-edit'),
-    path('wire/<int:pk>/delete/', views.ProjectWireDeleteView.as_view(), name='wire-delete'),
     
     # Hardware Management
     path('projects/<str:job_number>/hardware/', views.ProjectHardwareListView.as_view(), name='hardware-list'),
@@ -257,13 +251,6 @@ material_patterns = [
         path('<int:pk>/edit/', views.ProjectDeviceUpdateView.as_view(), name='device-edit'),
         path('<int:pk>/delete/', views.ProjectDeviceDeleteView.as_view(), name='device-delete'),
     ])),
-    path('wire/', include([
-        path('', views.ProjectWireListView.as_view(), name='wire-list'),
-        path('create/', views.ProjectWireCreateView.as_view(), name='wire-create'),
-        path('<int:pk>/', views.ProjectWireDetailView.as_view(), name='wire-detail'),
-        path('<int:pk>/edit/', views.ProjectWireUpdateView.as_view(), name='wire-edit'),
-        path('<int:pk>/delete/', views.ProjectWireDeleteView.as_view(), name='wire-delete'),
-    ])),
     # ... other material types
 ]
 
@@ -290,7 +277,7 @@ class ProjectURLConfig:
     @staticmethod
     def get_material_urls():
         """Get all material management URLs"""
-        material_types = ['device', 'wire', 'hardware', 'software', 'license', 'travel']
+        material_types = ['device', 'hardware', 'software', 'license', 'travel']
         return [url for url in urlpatterns if any(mat_type in str(url.pattern) for mat_type in material_types)]
 
 # ============================================
@@ -336,7 +323,7 @@ Project URL Structure Documentation:
    - /projects/projects/{job_number}/edit/ - Edit project
 
 3. Material Management:
-   Each material type (devices, wire, hardware, software, licenses, travel) follows the pattern:
+   Each material type (devices, hardware, software, licenses, travel) follows the pattern:
    - /projects/projects/{job_number}/{material_type}/ - List items
    - /projects/projects/{job_number}/{material_type}/create/ - Add new item
    - /projects/{material_type}/{pk}/ - Item detail/edit/delete

--- a/project/views.py
+++ b/project/views.py
@@ -42,7 +42,7 @@ from .models import (
     ProjectChange, ProjectMilestone
 )
 from .forms import (
-    ProjectForm, ScopeOfWorkForm, DeviceForm, WireForm, 
+    ProjectForm, ScopeOfWorkForm, DeviceForm,
     HardwareForm, SoftwareForm, LicenseForm, TravelForm
 )
 from .serializers import ProjectSerializer, ScopeOfWorkSerializer
@@ -1153,7 +1153,6 @@ class ProjectMaterialsView(ProjectAccessMixin, DetailView):
         # Get all material types
         context.update({
             'devices': project.device_items.all(),
-            'wire_items': getattr(project, 'wire_items', []),
             'hardware_items': getattr(project, 'hardware_items', []),
             'software_items': getattr(project, 'software_items', []),
             'license_items': getattr(project, 'license_items', []),
@@ -1170,7 +1169,6 @@ class ProjectMaterialsView(ProjectAccessMixin, DetailView):
             return {
                 'total_items': (
                     project.device_items.count() +
-                    getattr(project, 'wire_items', []).count() if hasattr(getattr(project, 'wire_items', []), 'count') else 0 +
                     getattr(project, 'hardware_items', []).count() if hasattr(getattr(project, 'hardware_items', []), 'count') else 0 +
                     getattr(project, 'software_items', []).count() if hasattr(getattr(project, 'software_items', []), 'count') else 0 +
                     getattr(project, 'license_items', []).count() if hasattr(getattr(project, 'license_items', []), 'count') else 0 +


### PR DESCRIPTION
## Summary
- drop unused `WireForm` import and wire references
- clean up material cost helpers by removing `wire_cost`
- strip wire routes and docs to keep terminology generic

## Testing
- `python manage.py check`

------
https://chatgpt.com/codex/tasks/task_e_684fb05c87f48332a0293a2a2db1d793