### PR TITLE
Add material type views and remove legacy alias

### DIFF
--- a/project/admin.py
+++ b/project/admin.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from decimal import Decimal
 
 from .models import (
-    ProjectTemplate, Project, ScopeOfWork, ProjectDevice, ProjectChange, 
+    ProjectTemplate, Project, ScopeOfWork, ProjectMaterial, ProjectChange,
     ProjectMilestone
 )
 
@@ -24,12 +24,12 @@ class ScopeOfWorkInline(admin.TabularInline):
     )
     readonly_fields = ('created_at', 'updated_at')
 
-class ProjectDeviceInline(admin.TabularInline):
-    """Inline admin for project devices"""
-    model = ProjectDevice
+class ProjectMaterialInline(admin.TabularInline):
+    """Inline admin for project materials"""
+    model = ProjectMaterial
     extra = 0
     fields = (
-        'device', 'task', 'quantity', 'unit_cost', 
+        'product', 'material_type', 'task', 'quantity', 'unit_cost',
         'status', 'delivered_date', 'installed_date'
     )
     readonly_fields = ('total_cost_display', 'created_at')
@@ -271,7 +271,7 @@ class ProjectAdmin(admin.ModelAdmin):
         })
     )
 
-    inlines = [ScopeOfWorkInline, ProjectDeviceInline, ProjectChangeInline, ProjectMilestoneInline]
+    inlines = [ScopeOfWorkInline, ProjectMaterialInline, ProjectChangeInline, ProjectMilestoneInline]
 
     actions = [
         'mark_complete', 

--- a/project/forms.py
+++ b/project/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.forms import ModelForm
 
-from .models import Project, ScopeOfWork, ProjectDevice
+from .models import Project, ScopeOfWork, ProjectMaterial
 
 
 class ProjectForm(ModelForm):
@@ -20,14 +20,41 @@ class ScopeOfWorkForm(ModelForm):
         fields = "__all__"
 
 
-class DeviceForm(ModelForm):
-    """Form for project device items. Optionally limits the project queryset."""
+class MaterialForm(ModelForm):
+    """Generic form for project material items."""
 
-    def __init__(self, proj=None, *args, **kwargs):
+    def __init__(self, proj=None, material_type=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if proj:
             self.fields["project"].queryset = Project.objects.filter(job_number=proj)
+        if material_type:
+            self.fields["material_type"].initial = material_type
 
     class Meta:
-        model = ProjectDevice
+        model = ProjectMaterial
         fields = "__all__"
+
+
+class DeviceForm(MaterialForm):
+    def __init__(self, proj=None, *args, **kwargs):
+        super().__init__(proj=proj, material_type="device", *args, **kwargs)
+
+
+class HardwareForm(MaterialForm):
+    def __init__(self, proj=None, *args, **kwargs):
+        super().__init__(proj=proj, material_type="hardware", *args, **kwargs)
+
+
+class SoftwareForm(MaterialForm):
+    def __init__(self, proj=None, *args, **kwargs):
+        super().__init__(proj=proj, material_type="software", *args, **kwargs)
+
+
+class LicenseForm(MaterialForm):
+    def __init__(self, proj=None, *args, **kwargs):
+        super().__init__(proj=proj, material_type="license", *args, **kwargs)
+
+
+class TravelForm(MaterialForm):
+    def __init__(self, proj=None, *args, **kwargs):
+        super().__init__(proj=proj, material_type="travel", *args, **kwargs)


### PR DESCRIPTION
## Summary
- remove unused `ProjectDevice` alias in models
- add CRUD views for hardware, software, license, and travel materials

## Testing
- `python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684fb3f3ca8c8332807d3ba8411274ed