### PR TITLE
Fix missing project serializers

### DIFF
--- a/project/serializers.py
+++ b/project/serializers.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+
+from .models import Project, ScopeOfWork
+
+
+class ProjectSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Project
+        fields = "__all__"
+
+
+class ScopeOfWorkSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ScopeOfWork
+        fields = "__all__"


### PR DESCRIPTION
## Summary
- add a `project/serializers.py` with `ProjectSerializer` and `ScopeOfWorkSerializer`

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: settings.DATABASES improperly configured)*

------
https://chatgpt.com/codex/tasks/task_e_684fc18e8c208332aa508d8faa277496