### PR TITLE
Fix missing project permissions module

### DIFF
--- a/project/views.py
+++ b/project/views.py
@@ -46,7 +46,7 @@ from .forms import (
     HardwareForm, SoftwareForm, LicenseForm, TravelForm
 )
 from .serializers import ProjectSerializer, ScopeOfWorkSerializer
-from .permissions import ProjectAccessMixin, ProjectPermissionMixin
+
 from .utils import generate_job_number, calculate_project_metrics
 
 User = get_user_model()


### PR DESCRIPTION
## Summary
- remove import of nonexistent permissions module in project views

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: settings.DATABASES improperly configured)*

------
https://chatgpt.com/codex/tasks/task_e_684fc61f1cb48332a5dec20cae9192eb