### PR TITLE
Integrate permissions and serializers

### DIFF
--- a/project/urls.py
+++ b/project/urls.py
@@ -184,6 +184,11 @@ urlpatterns = [
         # File Uploads
         path('projects/<str:job_number>/upload-image/', views.ProjectImageUploadAPIView.as_view(), name='api-upload-image'),
         path('projects/<str:job_number>/upload-document/', views.ProjectDocumentUploadAPIView.as_view(), name='api-upload-document'),
+
+        # Serializer-based endpoints
+        path('projects/', views.ProjectListAPIView.as_view(), name='api-project-list'),
+        path('projects/<str:job_number>/', views.ProjectDetailAPIView.as_view(), name='api-project-detail'),
+        path('scope/', views.ScopeOfWorkListAPIView.as_view(), name='api-scope-list'),
     ])),
     
     # ============================================


### PR DESCRIPTION
## Summary
- reuse `ProjectAccessMixin` and `ProjectPermissionMixin` from permissions module
- expose DRF API views with existing serializers
- show project metrics using `calculate_project_metrics`
- protect CRUD views with new permission mixin
- wire up API endpoints for project and scope data

## Testing
- `python -m py_compile project/views.py project/urls.py`
- `python manage.py test` *(fails: settings.DATABASES is improperly configured)*

------
https://chatgpt.com/codex/tasks/task_e_684fc9a1d1bc83328c5fc4f47ea7f928