### PR TITLE
Fix missing timedelta import

### DIFF
--- a/project/models.py
+++ b/project/models.py
@@ -6,7 +6,7 @@ from django.core.validators import MinValueValidator, MaxValueValidator
 from django.contrib.contenttypes.fields import GenericRelation
 from decimal import Decimal
 import uuid
-from datetime import date
+from datetime import date, timedelta
 
 # Import from your modernized apps
 from client.models import TimeStampedModel, UUIDModel


### PR DESCRIPTION
## Summary
- fix missing timedelta import in Project model

## Testing
- `python -m py_compile project/models.py`
- `pytest -q` *(fails: ImportError in settings)*

------
https://chatgpt.com/codex/tasks/task_e_68511e952a988332b98b37390da832af