### PR TITLE
Fix project URLs by adding placeholder views

### DIFF
--- a/project/templates/project/placeholder.html
+++ b/project/templates/project/placeholder.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/views.py
+++ b/project/views.py
@@ -2661,6 +2661,163 @@ class SystemStatusView(LoginRequiredMixin, TemplateView):
         return sorted(activities, key=lambda x: x['timestamp'], reverse=True)
 
 # ============================================
+# Placeholder Views for Unimplemented Features
+# ============================================
+
+class PlaceholderView(LoginRequiredMixin, TemplateView):
+    """Generic placeholder view until functionality is implemented."""
+    template_name = 'project/placeholder.html'
+
+
+class NotImplementedAPIView(APIView):
+    """Simple API view returning a 501 response."""
+
+    def get(self, request, *args, **kwargs):
+        return Response({'detail': 'Not implemented'}, status=501)
+
+    post = put = patch = delete = get
+
+
+class ProjectChangeDetailView(PlaceholderView):
+    pass
+
+
+class ProjectChangeUpdateView(PlaceholderView):
+    pass
+
+
+class ProjectChangeDeleteView(PlaceholderView):
+    pass
+
+
+class ProjectMilestoneDetailView(PlaceholderView):
+    pass
+
+
+class ProjectMilestoneUpdateView(PlaceholderView):
+    pass
+
+
+class ProjectMilestoneDeleteView(PlaceholderView):
+    pass
+
+
+class ProjectTemplateListView(PlaceholderView):
+    pass
+
+
+class ProjectTemplateCreateView(PlaceholderView):
+    pass
+
+
+class ProjectTemplateDetailView(PlaceholderView):
+    pass
+
+
+class ProjectTemplateUpdateView(PlaceholderView):
+    pass
+
+
+class ProjectTemplateDeleteView(PlaceholderView):
+    pass
+
+
+class ProjectFromTemplateView(PlaceholderView):
+    pass
+
+
+class ProjectTeamRemoveView(PlaceholderView):
+    pass
+
+
+class FavoriteProjectsView(PlaceholderView):
+    pass
+
+
+class ToggleFavoriteView(PlaceholderView):
+    pass
+
+
+class ProjectDefaultsView(PlaceholderView):
+    pass
+
+
+class BusinessCategorySettingsView(PlaceholderView):
+    pass
+
+
+class ProjectExportSingleView(PlaceholderView):
+    pass
+
+
+class ProjectExcelExportView(PlaceholderView):
+    pass
+
+
+class ProjectImportView(PlaceholderView):
+    pass
+
+
+class ProjectScheduleView(PlaceholderView):
+    pass
+
+
+class ProjectValidationDetailView(PlaceholderView):
+    pass
+
+
+class ProjectAutocompleteView(NotImplementedAPIView):
+    pass
+
+
+class LocationAutocompleteView(NotImplementedAPIView):
+    pass
+
+
+class ProjectSearchAPIView(NotImplementedAPIView):
+    pass
+
+
+class ProjectQuickUpdateAPIView(NotImplementedAPIView):
+    pass
+
+
+class ProjectProgressUpdateAPIView(NotImplementedAPIView):
+    pass
+
+
+class ProjectStatusAPIView(NotImplementedAPIView):
+    pass
+
+
+class DashboardStatsAPIView(NotImplementedAPIView):
+    pass
+
+
+class ProjectNotificationsAPIView(NotImplementedAPIView):
+    pass
+
+
+class ProjectBulkUpdateAPIView(NotImplementedAPIView):
+    pass
+
+
+class ProjectBulkDeleteAPIView(NotImplementedAPIView):
+    pass
+
+
+class ProjectImageUploadAPIView(NotImplementedAPIView):
+    pass
+
+
+class ProjectDocumentUploadAPIView(NotImplementedAPIView):
+    pass
+
+
+class ProjectCalendarEventsAPIView(NotImplementedAPIView):
+    pass
+
+# ============================================
 # Error Handling Views
 # ============================================
 


### PR DESCRIPTION
## Summary
- add placeholder views and API stubs so project URLs resolve
- provide simple placeholder template for unfinished features

## Testing
- `python -m py_compile project/views.py`
- `python -m py_compile project/urls.py`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68511f9ac9688332a5567b7b99b6e4c3