### PR TITLE
Fix missing APIView import

### DIFF
--- a/project/views.py
+++ b/project/views.py
@@ -37,6 +37,7 @@ from rest_framework import generics, viewsets, status
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from .models import (
     Project, ProjectTemplate, ScopeOfWork, ProjectMaterial,


### PR DESCRIPTION
## Summary
- import `APIView` for custom DRF views

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: ModuleNotFoundError: No module named 'six', settings.DATABASES is improperly configured)*

------
https://chatgpt.com/codex/tasks/task_e_685121f61f10833287e3084d309e8e21