### PR TITLE
Implement basic WIP app URLs and list view

### DIFF
--- a/wip/templates/wip/wipitem_list.html
+++ b/wip/templates/wip/wipitem_list.html
@@ -1,0 +1,40 @@
+{% extends "home/base.html" %}
+{% load static %}
+
+{% block title %}<title>Work In Progress</title>{% endblock %}
+
+{% block breadcrumb %}
+<li class="breadcrumb-item active">WIP</li>
+{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+  <h1 class="h3 mb-4">Work In Progress</h1>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Description</th>
+        <th>Project</th>
+        <th>Assigned To</th>
+        <th>Status</th>
+        <th class="text-end">Progress</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in items %}
+      <tr>
+        <td>{{ item.description }}</td>
+        <td>{{ item.project }}</td>
+        <td>{{ item.assigned_to }}</td>
+        <td>{{ item.get_status_display }}</td>
+        <td class="text-end">{{ item.progress_percent }}%</td>
+      </tr>
+      {% empty %}
+      <tr>
+        <td colspan="5">No work-in-progress items.</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/wip/urls.py
+++ b/wip/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from . import views
+
+app_name = "wip"
+
+urlpatterns = [
+    path("", views.WIPItemListView.as_view(), name="list"),
+]

--- a/wip/views.py
+++ b/wip/views.py
@@ -1,0 +1,12 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import ListView
+
+from .models import WIPItem
+
+
+class WIPItemListView(LoginRequiredMixin, ListView):
+    """Simple list view for work-in-progress items."""
+    model = WIPItem
+    template_name = "wip/wipitem_list.html"
+    context_object_name = "items"
+    paginate_by = 25


### PR DESCRIPTION
## Summary
- add a simple list view for `WIPItem`
- hook up a `/wip/` route
- provide a basic template for listing items

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: settings.DATABASES is improperly configured)*

------
https://chatgpt.com/codex/tasks/task_e_685123ada7688332b61a0b4b620e8a3a