### PR TITLE
Fix duplicate import and tagline typo

### DIFF
--- a/home/templates/registration/login.html
+++ b/home/templates/registration/login.html
@@ -20,7 +20,7 @@
 <body class="bg-dark">
   <div class="container">
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top" id="mainNav">
-    <a class="navbar-brand" href="">Distrobution Solutions Login</a></nav>
+    <a class="navbar-brand" href="">Distribution Solutions Login</a></nav>
     <div class="card card-login mx-auto mt-5">
     {% block pass_reset %}
       <div class="card-header">

--- a/wbee/urls.py
+++ b/wbee/urls.py
@@ -4,9 +4,8 @@ from django.contrib import admin
 from django.urls import include, path
 from django.contrib.staticfiles.urls import static
 from django.conf import settings
-from django.urls import path, re_path
 
-admin.site.site_header = "Distrobution Solutions"
+admin.site.site_header = "Distribution Solutions"
 admin.site.index_title = "Database administration configuration."
 
 urlpatterns = [


### PR DESCRIPTION
## Summary
- clean up urls imports
- fix incorrect "Distrobution" spelling on login page and admin header

## Testing
- `python -m pip install -r requirements.txt`
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: settings.DATABASES is improperly configured)*


------
https://chatgpt.com/codex/tasks/task_e_6854d80c9c208332b35cbebf3ce8425b