### PR TITLE
Fix DJANGO_SETTINGS_MODULE

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -6,7 +6,9 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wbee.settings')
+    # Use the base settings module, which reads from environment variables and
+    # optional .env files for secure configuration.
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wbee.settings.base')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
## Summary
- ensure manage.py uses `wbee.settings.base`
- document .env usage

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: settings not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6854d7f7cc74833299396010e0bd06f0