### PR TITLE
Fix project task references

### DIFF
--- a/project/models.py
+++ b/project/models.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.urls import reverse
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.contrib.contenttypes.fields import GenericRelation
+from django.apps import apps
 from decimal import Decimal
 import uuid
 from datetime import date, timedelta
@@ -360,6 +361,12 @@ class Project(UUIDModel, TimeStampedModel):
         return None
     
     # Task and material relationships
+    @property
+    def tasks(self):
+        """Return all tasks associated with this project."""
+        Task = apps.get_model('todo', 'Task')
+        return Task.objects.filter(task_list__project=self)
+
     @property
     def total_tasks(self):
         """Get total number of tasks"""

--- a/project/views.py
+++ b/project/views.py
@@ -301,7 +301,7 @@ class ProjectListView(LoginRequiredMixin, OptimizedQuerysetMixin, ListView):
         Prefetch('milestones', queryset=ProjectMilestone.objects.filter(is_critical=True))
     ]
     annotations = {
-        'task_count': Count('tasks'),
+        'task_count': Count('task_lists__tasks'),
         'team_size': Count('team_members', distinct=True),
         'milestone_count': Count('milestones'),
     }
@@ -908,8 +908,8 @@ class ProjectProgressView(ProjectAccessMixin, DetailView):
         
         # Progress breakdown by scope items
         scope_progress = project.scope_items.annotate(
-            task_count=Count('tasks'),
-            completed_tasks=Count('tasks', filter=Q(tasks__completed=True))
+            task_count=Count('task_lists__tasks'),
+            completed_tasks=Count('task_lists__tasks', filter=Q(task_lists__tasks__completed=True))
         ).values(
             'area', 'system_type', 'percent_complete', 
             'task_count', 'completed_tasks'
@@ -2170,8 +2170,8 @@ class ProgressReportView(LoginRequiredMixin, TemplateView):
         context = super().get_context_data(**kwargs)
         
         projects = Project.objects.select_related('project_manager').annotate(
-            task_count=Count('tasks'),
-            completed_tasks=Count('tasks', filter=Q(tasks__completed=True)),
+            task_count=Count('task_lists__tasks'),
+            completed_tasks=Count('task_lists__tasks', filter=Q(task_lists__tasks__completed=True)),
             milestone_count=Count('milestones'),
             completed_milestones=Count('milestones', filter=Q(milestones__is_complete=True))
         )


### PR DESCRIPTION
## Summary
- fix `ProjectListView` annotations for task counts
- support fetching project tasks via TaskList relations

## Testing
- `python manage.py check` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6854f81e91ec8332892d22b5ffb9094e