### PR TITLE
Restrict admin to superusers

### DIFF
--- a/home/templates/home/home.html
+++ b/home/templates/home/home.html
@@ -524,9 +524,11 @@
                     <a href="#" class="btn btn-outline-warning btn-sm">
                         <i class="fas fa-file"></i> View Reports
                     </a>
+                    {% if request.user.is_superuser %}
                     <a href="/admin/" class="btn btn-outline-secondary btn-sm">
                         <i class="fas fa-cogs"></i> Admin Panel
                     </a>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/wbee/urls.py
+++ b/wbee/urls.py
@@ -8,6 +8,12 @@ from django.conf import settings
 admin.site.site_header = "Distribution Solutions"
 admin.site.index_title = "Database administration configuration."
 
+# Restrict Django admin to superusers only
+def _superuser_only(request):
+    return request.user.is_active and request.user.is_superuser
+
+admin.site.has_permission = _superuser_only
+
 urlpatterns = [
     path("", include("home.urls")),
     path("grappelli/", include("grappelli.urls")),


### PR DESCRIPTION
## Summary
- hide Admin Panel button unless user is superuser
- lock Django admin to superusers only

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: connection to PostgreSQL refused)*

------
https://chatgpt.com/codex/tasks/task_e_6854f8c116f8833287ba19e63c8d1805