### PR TITLE
Fix location templates using wrong base

### DIFF
--- a/location/templates/location/dashboard.html
+++ b/location/templates/location/dashboard.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "home/base.html" %}
 {% load static %}
 {% load humanize %}
 

--- a/location/templates/location/document_confirm_delete.html
+++ b/location/templates/location/document_confirm_delete.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "home/base.html" %}
 {% load static %}
 {% load humanize %}
 

--- a/location/templates/location/document_detail.html
+++ b/location/templates/location/document_detail.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "home/base.html" %}
 {% load static %}
 {% load humanize %}
 

--- a/location/templates/location/document_form.html
+++ b/location/templates/location/document_form.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "home/base.html" %}
 {% load static %}
 {% load widget_tweaks %}
 

--- a/location/templates/location/document_list.html
+++ b/location/templates/location/document_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "home/base.html" %}
 {% load static %}
 {% load humanize %}
 

--- a/location/templates/location/location_form.html
+++ b/location/templates/location/location_form.html
@@ -1153,7 +1153,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 }
 </style>
-{% endblock %}{% extends "base.html" %}
+{% endblock %}{% extends "home/base.html" %}
 {% load static %}
 {% load widget_tweaks %}
 

--- a/location/templates/location/location_list.html
+++ b/location/templates/location/location_list.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "home/base.html" %}
 {% load static %}
 {% load humanize %}
 

--- a/location/templates/location/location_map.html
+++ b/location/templates/location/location_map.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "home/base.html" %}
 {% load static %}
 
 {% block title %}Locations Map{% endblock %}


### PR DESCRIPTION
## Summary
- use `home/base.html` as the template base for location pages

## Testing
- `pip install -q -r requirements.txt`
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: helpdesk app not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6854fb2a0ec0833292bce65079900a96