### PR TITLE
Fix assignment namespace mismatch

### DIFF
--- a/asset/urls.py
+++ b/asset/urls.py
@@ -132,7 +132,10 @@ urlpatterns = [
     path('maintenance/', include(maintenance_patterns)),
     
     # Assignment management  
-    path('assignments/', include(assignment_patterns)),
+    path(
+        'assignments/',
+        include((assignment_patterns, 'assignments'), namespace='assignments'),
+    ),
     
     # API endpoints
     path('api/', include(api_patterns)),


### PR DESCRIPTION
## Summary
- fix `asset` assignments URL namespace

## Testing
- `python -m pip install -q -r requirements.txt`
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6854fb382ff4833284c2c4ba15369ef1