### PR TITLE
Add asset maintenance templates

### DIFF
--- a/asset/templates/asset/maintenance_confirm_delete.html
+++ b/asset/templates/asset/maintenance_confirm_delete.html
@@ -1,0 +1,18 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Delete Maintenance Record</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'asset:maintenance:list' %}">Maintenance</a></li>
+<li class="breadcrumb-item active">Delete</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-body">
+    <p>Are you sure you want to delete this maintenance record?</p>
+    <form method="post">
+      {% csrf_token %}
+      <button type="submit" class="btn btn-danger">Delete</button>
+      <a href="{% url 'asset:maintenance:detail' object.pk %}" class="btn btn-secondary">Cancel</a>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/asset/templates/asset/maintenance_detail.html
+++ b/asset/templates/asset/maintenance_detail.html
@@ -1,0 +1,32 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Maintenance Detail</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'asset:maintenance:list' %}">Maintenance</a></li>
+<li class="breadcrumb-item active">Detail</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header d-flex justify-content-between">
+    <h6 class="m-0 font-weight-bold text-primary">{{ maintenance_record.asset.name }}</h6>
+    {% if perms.asset.change_assetmaintenancerecord %}
+      <a href="{% url 'asset:maintenance:update' maintenance_record.pk %}" class="btn btn-sm btn-outline-primary">
+        <i class="fas fa-edit"></i> Edit
+      </a>
+    {% endif %}
+  </div>
+  <div class="card-body">
+    <dl class="row">
+      <dt class="col-sm-3">Performed Date</dt>
+      <dd class="col-sm-9">{{ maintenance_record.performed_date }}</dd>
+      <dt class="col-sm-3">Type</dt>
+      <dd class="col-sm-9">{{ maintenance_record.get_maintenance_type_display }}</dd>
+      <dt class="col-sm-3">Performed By</dt>
+      <dd class="col-sm-9">{{ maintenance_record.performed_by }}</dd>
+      <dt class="col-sm-3">Description</dt>
+      <dd class="col-sm-9">{{ maintenance_record.description|linebreaksbr }}</dd>
+      <dt class="col-sm-3">Cost</dt>
+      <dd class="col-sm-9">${{ maintenance_record.total_cost|floatformat:2 }}</dd>
+    </dl>
+  </div>
+</div>
+{% endblock %}

--- a/asset/templates/asset/maintenance_form.html
+++ b/asset/templates/asset/maintenance_form.html
@@ -1,0 +1,21 @@
+{% extends "home/base.html" %}
+{% block title %}<title>{% if object %}Edit{% else %}Add{% endif %} Maintenance</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'asset:maintenance:list' %}">Maintenance</a></li>
+<li class="breadcrumb-item active">{% if object %}Edit{% else %}Add{% endif %}</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header">
+    <h6 class="m-0 font-weight-bold text-primary">{% if object %}Edit{% else %}Add{% endif %} Maintenance</h6>
+  </div>
+  <div class="card-body">
+    <form method="post">
+      {% csrf_token %}
+      {{ form.as_p }}
+      <button type="submit" class="btn btn-primary">Save</button>
+      <a href="{% url 'asset:maintenance:list' %}" class="btn btn-secondary">Cancel</a>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/asset/templates/asset/maintenance_list.html
+++ b/asset/templates/asset/maintenance_list.html
@@ -1,0 +1,42 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Maintenance Records</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'asset:dashboard' %}">Assets</a></li>
+<li class="breadcrumb-item active">Maintenance</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header d-flex justify-content-between">
+    <h6 class="m-0 font-weight-bold text-primary">Maintenance Records</h6>
+    {% if perms.asset.add_assetmaintenancerecord %}
+      <a href="{% url 'asset:maintenance:create' %}" class="btn btn-primary btn-sm">
+        <i class="fas fa-plus"></i> Add Record
+      </a>
+    {% endif %}
+  </div>
+  <div class="card-body p-0">
+    <table class="table table-striped mb-0">
+      <thead>
+        <tr>
+          <th>Asset</th>
+          <th>Date</th>
+          <th>Type</th>
+          <th class="text-end">Cost</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for record in maintenance_records %}
+        <tr>
+          <td><a href="{{ record.asset.get_absolute_url }}">{{ record.asset.name }}</a></td>
+          <td>{{ record.performed_date }}</td>
+          <td>{{ record.get_maintenance_type_display }}</td>
+          <td class="text-end">${{ record.total_cost|floatformat:2 }}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="4" class="text-center">No maintenance records found.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/asset/templates/asset/maintenance_overdue.html
+++ b/asset/templates/asset/maintenance_overdue.html
@@ -1,0 +1,29 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Overdue Maintenance</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'asset:maintenance:list' %}">Maintenance</a></li>
+<li class="breadcrumb-item active">Overdue</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header"><h6 class="m-0">Overdue Maintenance</h6></div>
+  <div class="card-body p-0">
+    <table class="table table-striped mb-0">
+      <thead>
+        <tr><th>Asset</th><th>Next Date</th><th>Assigned</th></tr>
+      </thead>
+      <tbody>
+        {% for asset in assets %}
+        <tr>
+          <td><a href="{{ asset.get_absolute_url }}">{{ asset.name }}</a></td>
+          <td>{{ asset.next_maintenance_date }}</td>
+          <td>{{ asset.assigned_worker.get_full_name|default:'-' }}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="3" class="text-center">No assets found.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/asset/templates/asset/maintenance_schedule_overview.html
+++ b/asset/templates/asset/maintenance_schedule_overview.html
@@ -1,0 +1,40 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Maintenance Schedule</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'asset:maintenance:list' %}">Maintenance</a></li>
+<li class="breadcrumb-item active">Schedule</li>
+{% endblock %}
+{% block content %}
+<div class="row">
+  <div class="col-lg-4">
+    <div class="card mb-4">
+      <div class="card-header bg-danger text-white">Overdue</div>
+      <ul class="list-group list-group-flush">
+        {% for asset in overdue_maintenance %}
+        <li class="list-group-item"><a href="{{ asset.get_absolute_url }}">{{ asset.name }}</a></li>
+        {% empty %}<li class="list-group-item text-center">None</li>{% endfor %}
+      </ul>
+    </div>
+  </div>
+  <div class="col-lg-4">
+    <div class="card mb-4">
+      <div class="card-header bg-warning">Due Today</div>
+      <ul class="list-group list-group-flush">
+        {% for asset in due_today %}
+        <li class="list-group-item"><a href="{{ asset.get_absolute_url }}">{{ asset.name }}</a></li>
+        {% empty %}<li class="list-group-item text-center">None</li>{% endfor %}
+      </ul>
+    </div>
+  </div>
+  <div class="col-lg-4">
+    <div class="card mb-4">
+      <div class="card-header bg-info text-white">Upcoming</div>
+      <ul class="list-group list-group-flush">
+        {% for asset in upcoming_maintenance %}
+        <li class="list-group-item"><a href="{{ asset.get_absolute_url }}">{{ asset.name }}</a></li>
+        {% empty %}<li class="list-group-item text-center">None</li>{% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/asset/templates/asset/maintenance_upcoming.html
+++ b/asset/templates/asset/maintenance_upcoming.html
@@ -1,0 +1,29 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Upcoming Maintenance</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'asset:maintenance:list' %}">Maintenance</a></li>
+<li class="breadcrumb-item active">Upcoming</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header"><h6 class="m-0">Upcoming Maintenance</h6></div>
+  <div class="card-body p-0">
+    <table class="table table-striped mb-0">
+      <thead>
+        <tr><th>Asset</th><th>Next Date</th><th>Assigned</th></tr>
+      </thead>
+      <tbody>
+        {% for asset in assets %}
+        <tr>
+          <td><a href="{{ asset.get_absolute_url }}">{{ asset.name }}</a></td>
+          <td>{{ asset.next_maintenance_date }}</td>
+          <td>{{ asset.assigned_worker.get_full_name|default:'-' }}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="3" class="text-center">No assets found.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add templates for viewing and managing maintenance records

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test asset`

------
https://chatgpt.com/codex/tasks/task_e_68550303a4d083329d60a7d2c6d7a978