### PR TITLE
Fix quick action links

### DIFF
--- a/home/templates/home/home.html
+++ b/home/templates/home/home.html
@@ -515,13 +515,13 @@
                     <a href="{% url 'home:contact' %}" class="btn btn-outline-primary btn-sm">
                         <i class="fas fa-envelope"></i> Contact Support
                     </a>
-                    <a href="#" class="btn btn-outline-info btn-sm">
+                    <a href="{% url 'asset:create' %}" class="btn btn-outline-info btn-sm">
                         <i class="fas fa-plus"></i> Add Asset
                     </a>
-                    <a href="#" class="btn btn-outline-success btn-sm">
+                    <a href="{% url 'project:project-schedule' %}" class="btn btn-outline-success btn-sm">
                         <i class="fas fa-calendar"></i> Schedule Event
                     </a>
-                    <a href="#" class="btn btn-outline-warning btn-sm">
+                    <a href="{% url 'project:reports' %}" class="btn btn-outline-warning btn-sm">
                         <i class="fas fa-file"></i> View Reports
                     </a>
                     {% if request.user.is_superuser %}


### PR DESCRIPTION
## Summary
- update Quick Action URLs on the home dashboard

## Testing
- `DATABASE_URL=sqlite://:memory: python manage.py test` *(fails: helpdesk namespace not registered)*

------
https://chatgpt.com/codex/tasks/task_e_68550365b6d88332abe54a3510d8e5ae