### PR TITLE
Fix maintenance URL namespace

### DIFF
--- a/asset/urls.py
+++ b/asset/urls.py
@@ -129,7 +129,10 @@ urlpatterns = [
     path('categories/', include(category_patterns)),
     
     # Maintenance management
-    path('maintenance/', include(maintenance_patterns)),
+    path(
+        'maintenance/',
+        include((maintenance_patterns, 'maintenance'), namespace='maintenance'),
+    ),
     
     # Assignment management  
     path(


### PR DESCRIPTION
## Summary
- namespace maintenance URLs so templates can resolve

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: NoReverseMatch: 'helpdesk' is not a registered namespace)*

------
https://chatgpt.com/codex/tasks/task_e_685505294fe88332b0444422bcad3a65