### PR TITLE
Fix worker permission API

### DIFF
--- a/hr/models.py
+++ b/hr/models.py
@@ -464,10 +464,14 @@ class Worker(AbstractBaseUser, UUIDModel, TimeStampedModel):
     def has_perm(self, perm, obj=None):
         """Does the worker have a specific permission?"""
         return self.is_admin
-    
+
     def has_module_perms(self, app_label):
         """Does the worker have permissions to view the app?"""
         return self.is_staff
+
+    def has_perms(self, perm_list, obj=None):
+        """Return True if the user has each of the specified permissions."""
+        return all(self.has_perm(perm, obj=obj) for perm in perm_list)
     
     # Employee information properties
     @property

--- a/project/templates/project/project_list.html
+++ b/project/templates/project/project_list.html
@@ -8,9 +8,11 @@
 <div class="card shadow mb-4">
   <div class="card-header py-3 d-flex justify-content-between">
     <h6 class="m-0 font-weight-bold text-primary">Projects</h6>
+    {% if user.is_superuser or user.is_admin %}
     <a href="{% url 'project:project-create' %}" class="btn btn-primary btn-sm">
       <i class="fas fa-plus"></i> Add Project
     </a>
+    {% endif %}
   </div>
   <div class="card-body p-0">
     <table class="table table-striped mb-0">


### PR DESCRIPTION
## Summary
- implement `Worker.has_perms` so Django permission mixins work
- show "Add Project" button only for administrators

## Testing
- `python -m py_compile hr/models.py`
- `python manage.py test` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68550912f38883328dff958c6605c7e4