### PR TITLE
Add asset category templates

### DIFF
--- a/asset/templates/asset/category_assets.html
+++ b/asset/templates/asset/category_assets.html
@@ -1,0 +1,32 @@
+{% extends "home/base.html" %}
+{% block title %}<title>{{ category.name }} Assets</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'asset:categories:list' %}">Asset Categories</a></li>
+<li class="breadcrumb-item"><a href="{% url 'asset:categories:detail' category.pk %}">{{ category.name }}</a></li>
+<li class="breadcrumb-item active">Assets</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header py-3">
+    <h6 class="m-0 font-weight-bold text-primary">Assets in {{ category.name }}</h6>
+  </div>
+  <div class="card-body p-0">
+    <table class="table table-striped mb-0">
+      <thead>
+        <tr>
+          <th>Asset</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for asset in assets %}
+        <tr>
+          <td><a href="{% url 'asset:detail' asset.pk %}">{{ asset.name }}</a></td>
+        </tr>
+        {% empty %}
+        <tr><td class="text-center">No assets found.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}

--- a/asset/templates/asset/category_confirm_delete.html
+++ b/asset/templates/asset/category_confirm_delete.html
@@ -1,0 +1,20 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Delete Category</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'asset:categories:list' %}">Asset Categories</a></li>
+<li class="breadcrumb-item active">Delete</li>
+{% endblock %}
+{% block content %}
+<form method="post">
+  {% csrf_token %}
+  <div class="card shadow mb-4">
+    <div class="card-body">
+      <p>Are you sure you want to delete {{ object.name }}?</p>
+      <div class="text-end">
+        <button type="submit" class="btn btn-danger">Delete</button>
+        <a href="{% url 'asset:categories:detail' object.pk %}" class="btn btn-secondary">Cancel</a>
+      </div>
+    </div>
+  </div>
+</form>
+{% endblock %}

--- a/asset/templates/asset/category_detail.html
+++ b/asset/templates/asset/category_detail.html
@@ -1,0 +1,23 @@
+{% extends "home/base.html" %}
+{% block title %}<title>{{ category.name }}</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'asset:categories:list' %}">Asset Categories</a></li>
+<li class="breadcrumb-item active">{{ category.name }}</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header py-3 d-flex justify-content-between">
+    <h6 class="m-0 font-weight-bold text-primary">{{ category.name }}</h6>
+    <div>
+      <a href="{% url 'asset:categories:update' category.pk %}" class="btn btn-sm btn-secondary"><i class="fas fa-edit"></i></a>
+      <a href="{% url 'asset:categories:delete' category.pk %}" class="btn btn-sm btn-danger"><i class="fas fa-trash"></i></a>
+    </div>
+  </div>
+  <div class="card-body">
+    <p>{{ category.description }}</p>
+    <a href="{% url 'asset:categories:assets' category.pk %}" class="btn btn-outline-primary btn-sm">
+      View Assets ({{ category.asset_count }})
+    </a>
+  </div>
+</div>
+{% endblock %}

--- a/asset/templates/asset/category_form.html
+++ b/asset/templates/asset/category_form.html
@@ -1,0 +1,28 @@
+{% extends "home/base.html" %}
+{% block title %}<title>{% if form.instance.pk %}Edit Category{% else %}Add Category{% endif %}</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'asset:categories:list' %}">Asset Categories</a></li>
+<li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Create{% endif %}</li>
+{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-8">
+    <div class="card shadow">
+      <div class="card-header py-3">
+        <h6 class="m-0 font-weight-bold text-primary">
+          {% if form.instance.pk %}<i class="fas fa-edit"></i> Edit Category{% else %}<i class="fas fa-plus"></i> Add Category{% endif %}
+        </h6>
+      </div>
+      <div class="card-body">
+        <form method="post" enctype="multipart/form-data">
+          {% csrf_token %}
+          {{ form.as_p }}
+          <div class="text-end">
+            <button type="submit" class="btn btn-primary">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/asset/templates/asset/category_list.html
+++ b/asset/templates/asset/category_list.html
@@ -1,0 +1,35 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Asset Categories</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item active">Asset Categories</li>
+{% endblock %}
+{% block content %}
+<div class="card shadow mb-4">
+  <div class="card-header py-3 d-flex justify-content-between">
+    <h6 class="m-0 font-weight-bold text-primary">Categories</h6>
+    <a href="{% url 'asset:categories:create' %}" class="btn btn-primary btn-sm">
+      <i class="fas fa-plus"></i> Add Category
+    </a>
+  </div>
+  <div class="card-body p-0">
+    <table class="table table-striped mb-0">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Assets</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for category in categories %}
+        <tr>
+          <td><a href="{% url 'asset:categories:detail' category.pk %}">{{ category.name }}</a></td>
+          <td>{{ category.asset_count }}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="2" class="text-center">No categories found.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add templates for listing and managing asset categories

## Testing
- `python manage.py check --settings wbee.settings.settings_test`
- `DJANGO_SETTINGS_MODULE=wbee.settings.settings_test pytest asset/tests.py::TestCase -q`
- `DJANGO_SETTINGS_MODULE=wbee.settings.settings_test pytest -q` *(fails: Model class helpdesk.models.base.Queue doesn't declare an app_label)*

------
https://chatgpt.com/codex/tasks/task_e_68550b3ccad48332a3a8cdd8b5741410