### PR TITLE
Fix prefetch field for project detail view

### DIFF
--- a/project/views.py
+++ b/project/views.py
@@ -408,11 +408,11 @@ class ProjectDetailView(ProjectAccessMixin, DetailView):
     
     def get_queryset(self):
         return super().get_queryset().select_related(
-            'location', 'location__client', 'project_manager', 
+            'location', 'location__client', 'project_manager',
             'estimator', 'supervisor'
         ).prefetch_related(
             'team_leads', 'team_members', 'scope_items',
-            'device_items', 'changes', 'milestones'
+            'material_items', 'changes', 'milestones'
         )
     
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
## Summary
- prefetch actual `material_items` relation instead of invalid `device_items`

## Testing
- `pytest -q` *(fails: ImportError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68551011d7208332b468e0432a29c5e2