### PR TITLE
Fix asset categories URL namespace

### DIFF
--- a/asset/urls.py
+++ b/asset/urls.py
@@ -126,7 +126,10 @@ urlpatterns = [
     path('', include(asset_patterns)),
     
     # Category management
-    path('categories/', include(category_patterns)),
+    path(
+        'categories/',
+        include((category_patterns, 'categories'), namespace='categories'),
+    ),
     
     # Maintenance management
     path(


### PR DESCRIPTION
## Summary
- ensure `asset` app includes categories under its own namespace

## Testing
- `pip install -r requirements.txt`
- `pytest -q --ds=wbee.settings.settings_test` *(fails: RuntimeError during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68551171ae0c83329016a03f0a94b15e