### PR TITLE
Fix TemplateSyntaxError in asset list template

### DIFF
--- a/asset/templates/asset/asset_list.html
+++ b/asset/templates/asset/asset_list.html
@@ -11,7 +11,14 @@
 
 {% block styler %}
 <link href="{% static 'home/css/asset-management.css' %}" rel="stylesheet" type="text/css">
-{% endblock %} 50%;
+<style>
+    .table-actions {
+        min-width: 200px;
+    }
+    .condition-indicator {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
         display: inline-block;
         margin-right: 5px;
     }


### PR DESCRIPTION
## Summary
- fix unmatched endblock tag in `asset_list.html`

## Testing
- `python manage.py test -v 2` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855135434288332830c718ce8fccbca