### PR TITLE
Add client effort list

### DIFF
--- a/client/templates/client/client_detail.html
+++ b/client/templates/client/client_detail.html
@@ -609,6 +609,9 @@
             <a href="{% url 'client:financial-dashboard' client_detail.id %}" class="btn btn-outline-success">
               <i class="fas fa-chart-line me-2"></i>Financial Dashboard
             </a>
+            <a href="{% url 'client:efforts' client_detail.id %}" class="btn btn-outline-secondary">
+              <i class="fas fa-tasks me-2"></i>Efforts
+            </a>
             <a href="#" class="btn btn-outline-info">
               <i class="fas fa-file-invoice me-2"></i>Create Invoice
             </a>

--- a/client/templates/client/client_effort_list.html
+++ b/client/templates/client/client_effort_list.html
@@ -1,0 +1,43 @@
+{% extends "home/base.html" %}
+{% load static %}
+
+{% block title %}<title>{{ client.company_name }} - Efforts</title>{% endblock %}
+
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'client:dashboard' %}">Client Management</a></li>
+<li class="breadcrumb-item"><a href="{% url 'client:list' %}">Directory</a></li>
+<li class="breadcrumb-item"><a href="{{ client.get_absolute_url }}">{{ client.company_name }}</a></li>
+<li class="breadcrumb-item active">Efforts</li>
+{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+  <h1 class="h3 mb-4">{{ client.company_name }} - Efforts</h1>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Description</th>
+        <th>Project</th>
+        <th>Assigned To</th>
+        <th>Status</th>
+        <th class="text-end">Progress</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in effort_list %}
+      <tr>
+        <td>{{ item.description }}</td>
+        <td>{{ item.project }}</td>
+        <td>{{ item.assigned_to }}</td>
+        <td>{{ item.get_status_display }}</td>
+        <td class="text-end">{{ item.progress_percent }}%</td>
+      </tr>
+      {% empty %}
+      <tr>
+        <td colspan="5">No efforts for this client.</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/client/templates/client/client_list.html
+++ b/client/templates/client/client_list.html
@@ -345,6 +345,9 @@
                   <a class="dropdown-item" href="{{ client.get_absolute_url }}">
                     <i class="fas fa-eye me-2"></i>View Details
                   </a>
+                  <a class="dropdown-item" href="{% url 'client:efforts' client.id %}">
+                    <i class="fas fa-tasks me-2"></i>Efforts
+                  </a>
                   {% if request.user.staff %}
                   <a class="dropdown-item" href="{% url 'update-client' client.id %}">
                     <i class="fas fa-edit me-2"></i>Edit Client
@@ -470,6 +473,9 @@
                     <div class="dropdown-menu dropdown-menu-right">
                       <a class="dropdown-item" href="{{ client.get_absolute_url }}">
                         <i class="fas fa-eye me-2"></i>View
+                      </a>
+                      <a class="dropdown-item" href="{% url 'client:efforts' client.id %}">
+                        <i class="fas fa-tasks me-2"></i>Efforts
                       </a>
                       {% if request.user.staff %}
                       <a class="dropdown-item" href="{% url 'update-client' client.id %}">

--- a/client/urls.py
+++ b/client/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     
     # Financial views
     path('<uuid:pk>/financial/', views.client_financial_dashboard, name='financial-dashboard'),
+    path('<uuid:pk>/efforts/', views.ClientEffortListView.as_view(), name='efforts'),
     
     # Export/Import
     path('export/csv/', views.export_clients_csv, name='export-csv'),


### PR DESCRIPTION
## Summary
- add ClientEffortListView and url pattern
- link to new list from client pages
- add template for effort list

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68551651e558833288cf04186c9734cc