### PR TITLE
Fix missing widget_tweaks setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ django-filter
 django-import-export
 django-crispy-forms
 crispy-bootstrap5
+django-widget-tweaks
 dj-database-url
 python-decouple
 Pillow

--- a/wbee/settings/base.py
+++ b/wbee/settings/base.py
@@ -45,6 +45,7 @@ THIRD_PARTY_APPS = [
     'import_export',  # For data import/export
     'crispy_forms',  # For better forms
     'crispy_bootstrap5',  # Bootstrap 5 support
+    'widget_tweaks',  # Form rendering utilities
 ]
 
 LOCAL_APPS = [

--- a/wbee/settings/settings_test.py
+++ b/wbee/settings/settings_test.py
@@ -19,6 +19,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.sites',
+    'widget_tweaks',
     'client.apps.ClientConfig',
     'company.apps.CompanyConfig',
     'location.apps.LocationConfig',


### PR DESCRIPTION
## Summary
- enable `django-widget-tweaks` by adding to requirements and settings
- include `widget_tweaks` in the minimal test settings

## Testing
- `pip install -r requirements.txt`
- `DJANGO_SETTINGS_MODULE=wbee.settings.settings_test python manage.py test todo`

------
https://chatgpt.com/codex/tasks/task_e_685519ce3d1083328b631ee6a6721626