### PR TITLE
Fix admin event distributor field

### DIFF
--- a/schedule/admin.py
+++ b/schedule/admin.py
@@ -334,7 +334,7 @@ class EventAdmin(admin.ModelAdmin):
                 'project',
                 'location',
                 ('start_time', 'dist_time'),
-                'distributor'
+                'Supplier'
             )
         }),
         ('Staff Assignment', {


### PR DESCRIPTION
## Summary
- reference the correct field in EventAdmin's fieldset

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68551ee00fe483328ea2f3b5b38b6205