### PR TITLE
Add breadcrumb support to base template

### DIFF
--- a/home/templates/home/base.html
+++ b/home/templates/home/base.html
@@ -52,6 +52,13 @@
                     </div>
                 {% endfor %}
             {% endif %}
+            <!-- Breadcrumbs-->
+            <nav aria-label="breadcrumb">
+                <ol class="breadcrumb">
+                    <li class="breadcrumb-item"><a href="/">Dashboard</a></li>
+                    {% block breadcrumb %}{% endblock %}
+                </ol>
+            </nav>
             {% block content %}{% endblock %}
         </div>
     {% else %}


### PR DESCRIPTION
## Summary
- add breadcrumb navigation section in `home/base.html`

## Testing
- `python manage.py check`
- `python manage.py test` *(fails: connection to database refused)*

------
https://chatgpt.com/codex/tasks/task_e_6856303698688332874843e17ccae55b