### PR TITLE
Fix breadcrumb URL

### DIFF
--- a/project/templates/project/project_detail_full.html
+++ b/project/templates/project/project_detail_full.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 
 {% block title %}<title>Project details</title>{% endblock %}
-{% block breadcrumb %} / <a href="{% url 'jobsite-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / detail view{% endblock %}
+{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / detail view{% endblock %}
 
 {% block content %}
 <div class="row">

--- a/schedule/templates/schedule/delete_event.html
+++ b/schedule/templates/schedule/delete_event.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load i18n %}
 {% block title %}<title>Project info Delete</title> {% endblock %}
-{% block breadcrumb %} / <a href="{% url 'jobsite-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / Delete project info{% endblock %}
+{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / Delete project info{% endblock %}
 
 {% block content %}
 {% if request.user.admin %}

--- a/todo/templates/todo/add_list.html
+++ b/todo/templates/todo/add_list.html
@@ -2,7 +2,7 @@
 {% block page_heading %}{% endblock %}
 {% block title %}<title>Add Todo List</title>{% endblock %}
 
-{% block breadcrumb %} / <a href="{% url 'jobsite-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / To Do List creation
+{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / To Do List creation
 {% endblock %}
 
 {% block content %}

--- a/todo/templates/todo/list_detail.html
+++ b/todo/templates/todo/list_detail.html
@@ -4,7 +4,7 @@
 {% block title %}<title>Todo List: {{ task_list.name }}</title>
 {% endblock %}
 
-{% block breadcrumb %} / <a href="{% url 'jobsite-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / To Do List
+{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / To Do List
 {% endblock %}
 
 {% block content %}

--- a/todo/templates/todo/list_lists.html
+++ b/todo/templates/todo/list_lists.html
@@ -2,7 +2,7 @@
 
 {% block title %}<title>{{ list_title }} Todo Lists</title>{% endblock %}
 
-{% block breadcrumb %} / <a href="{% url 'jobsite-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / To Do List{% endblock %}
+{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / To Do List{% endblock %}
 
 {% block content %}
   <h1>Todo Lists</h1>

--- a/todo/templates/todo/task_detail.html
+++ b/todo/templates/todo/task_detail.html
@@ -2,7 +2,7 @@
 
 {% block title %}<title>Task:{{ task.title }}</title>{% endblock %}
 
-{% block breadcrumb %} / <a href="{% url 'jobsite-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / To Do List{% endblock %}
+{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / To Do List{% endblock %}
 
 {% block content %}
 <div class="row">


### PR DESCRIPTION
## Summary
- fix breadcrumbs referencing a deleted jobsite URL

## Testing
- `python manage.py test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685632dbf8188332ba5f0d13dd0124f5