### PR TITLE
Add missing project templates

### DIFF
--- a/project/templates/project/calendar.html
+++ b/project/templates/project/calendar.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/change_form.html
+++ b/project/templates/project/change_form.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/change_list.html
+++ b/project/templates/project/change_list.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/complete_projects.html
+++ b/project/templates/project/complete_projects.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/device_confirm_delete.html
+++ b/project/templates/project/device_confirm_delete.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/device_detail.html
+++ b/project/templates/project/device_detail.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/device_form.html
+++ b/project/templates/project/device_form.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/device_list.html
+++ b/project/templates/project/device_list.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/milestone_form.html
+++ b/project/templates/project/milestone_form.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/milestone_list.html
+++ b/project/templates/project/milestone_list.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/my_assignments.html
+++ b/project/templates/project/my_assignments.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/overdue_projects.html
+++ b/project/templates/project/overdue_projects.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/project_financial.html
+++ b/project/templates/project/project_financial.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/project_materials.html
+++ b/project/templates/project/project_materials.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/project_progress.html
+++ b/project/templates/project/project_progress.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/project_team.html
+++ b/project/templates/project/project_team.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/project_timeline.html
+++ b/project/templates/project/project_timeline.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/quick_actions.html
+++ b/project/templates/project/quick_actions.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/recently_viewed.html
+++ b/project/templates/project/recently_viewed.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/reports.html
+++ b/project/templates/project/reports.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/reports/financial_report.html
+++ b/project/templates/project/reports/financial_report.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/reports/progress_report.html
+++ b/project/templates/project/reports/progress_report.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/reports/team_performance.html
+++ b/project/templates/project/reports/team_performance.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/reports/utilization_report.html
+++ b/project/templates/project/reports/utilization_report.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/scope_confirm_delete.html
+++ b/project/templates/project/scope_confirm_delete.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/scope_detail.html
+++ b/project/templates/project/scope_detail.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/scope_form.html
+++ b/project/templates/project/scope_form.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/scope_list.html
+++ b/project/templates/project/scope_list.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/settings.html
+++ b/project/templates/project/settings.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}

--- a/project/templates/project/system_status.html
+++ b/project/templates/project/system_status.html
@@ -1,0 +1,7 @@
+{% extends "home/base.html" %}
+{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block content %}
+<div class="alert alert-warning mt-4">
+  This feature is not yet implemented.
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- fix missing templates for project app by reusing a placeholder page

## Testing
- `python manage.py check` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68563438df548332ac5e2d41e9581a50