### PR TITLE
Fix project list URL namespaces

### DIFF
--- a/project/templates/project/project_detail_full.html
+++ b/project/templates/project/project_detail_full.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 
 {% block title %}<title>Project details</title>{% endblock %}
-{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / detail view{% endblock %}
+{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project:project-list' %}">Project</a> / detail view{% endblock %}
 
 {% block content %}
 <div class="row">

--- a/schedule/templates/schedule/delete_event.html
+++ b/schedule/templates/schedule/delete_event.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load i18n %}
 {% block title %}<title>Project info Delete</title> {% endblock %}
-{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / Delete project info{% endblock %}
+{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project:project-list' %}">Project</a> / Delete project info{% endblock %}
 
 {% block content %}
 {% if request.user.admin %}

--- a/todo/templates/todo/add_list.html
+++ b/todo/templates/todo/add_list.html
@@ -2,12 +2,12 @@
 {% block page_heading %}{% endblock %}
 {% block title %}<title>Add Todo List</title>{% endblock %}
 
-{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / To Do List creation
+{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project:project-list' %}">Project</a> / To Do List creation
 {% endblock %}
 
 {% block content %}
   
-  <h2>Add a list to <a href="{% url 'project-detail' proj %}">Project: {{ proj }} </a></h2>
+  <h2>Add a list to <a href="{% url 'project:project-detail' proj %}">Project: {{ proj }} </a></h2>
 
   <form action="" method="post">
     {% csrf_token %}

--- a/todo/templates/todo/list_detail.html
+++ b/todo/templates/todo/list_detail.html
@@ -4,7 +4,7 @@
 {% block title %}<title>Todo List: {{ task_list.name }}</title>
 {% endblock %}
 
-{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / To Do List
+{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project:project-list' %}">Project</a> / To Do List
 {% endblock %}
 
 {% block content %}

--- a/todo/templates/todo/list_lists.html
+++ b/todo/templates/todo/list_lists.html
@@ -2,7 +2,7 @@
 
 {% block title %}<title>{{ list_title }} Todo Lists</title>{% endblock %}
 
-{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / To Do List{% endblock %}
+{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project:project-list' %}">Project</a> / To Do List{% endblock %}
 
 {% block content %}
   <h1>Todo Lists</h1>

--- a/todo/templates/todo/task_detail.html
+++ b/todo/templates/todo/task_detail.html
@@ -2,7 +2,7 @@
 
 {% block title %}<title>Task:{{ task.title }}</title>{% endblock %}
 
-{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project-list' %}">Project</a> / To Do List{% endblock %}
+{% block breadcrumb %} / <a href="{% url 'location:location-list' %}">Job Site</a> / <a href="{% url 'project:project-list' %}">Project</a> / To Do List{% endblock %}
 
 {% block content %}
 <div class="row">


### PR DESCRIPTION
## Summary
- fix namespace for project list links in templates

## Testing
- `pytest -q` *(fails: ImproperlyConfigured: Requested setting INSTALLED_APPS)*

------
https://chatgpt.com/codex/tasks/task_e_68563625afb88332afcf4d9f755a1ba5