### PR TITLE
Fix project PDF link

### DIFF
--- a/project/templates/project/project_detail_full.html
+++ b/project/templates/project/project_detail_full.html
@@ -14,7 +14,7 @@
           </div>
           <div class="col-lg-12">
             {% if request.user.is_staff %}
-              <a href="{% url 'project-pdf' project.job_number %}"><div class="add_jobsite"> Quote </div></a>&nbsp;<a href="{% url 'project:project-edit' project.job_number %}"><div class="add_jobsite"> edit </div></a>
+              <a href="{% url 'project:project-pdf' project.job_number %}"><div class="add_jobsite"> Quote </div></a>&nbsp;<a href="{% url 'project:project-edit' project.job_number %}"><div class="add_jobsite"> edit </div></a>
             {% endif %}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- fix URL namespace for Project PDF link

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: helpdesk namespace not registered)*

------
https://chatgpt.com/codex/tasks/task_e_68563737bb848332b9b15b8842348cc7