### PR TITLE
Add missing create-event route

### DIFF
--- a/schedule/urls.py
+++ b/schedule/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
 
 from .feeds import CalendarICalendar
+from . import views
 
 app_name = "schedule"
 
 urlpatterns = [
     path("<int:calendar_id>/ical/", CalendarICalendar(), name="calendar-ical"),
+    path("event/create/<str:proj>/", views.EventCreateView.as_view(), name="create-event"),
 ]

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -1,0 +1,31 @@
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.urls import reverse
+from django.views.generic import CreateView
+from django.shortcuts import get_object_or_404
+
+from .models import Event
+from .forms import NewEventForm
+from project.models import Project
+
+
+class EventCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
+    """Simple event creation view used in tests and examples."""
+
+    model = Event
+    form_class = NewEventForm
+    template_name = "schedule/create_event.html"
+
+    def test_func(self):
+        return self.request.user.is_staff
+
+    def get_initial(self):
+        initial = super().get_initial()
+        proj = self.kwargs.get("proj")
+        if proj and proj != "0":
+            project = Project.objects.filter(job_number=proj).first()
+            if project:
+                initial["project"] = project
+        return initial
+
+    def get_success_url(self):
+        return self.object.get_absolute_url()

--- a/wbee/urls.py
+++ b/wbee/urls.py
@@ -2,6 +2,7 @@
 
 from django.contrib import admin
 from django.urls import include, path
+from schedule.views import EventCreateView
 from django.contrib.staticfiles.urls import static
 from django.conf import settings
 
@@ -28,6 +29,7 @@ urlpatterns = [
     path('project/', include('project.urls')),
     path('material/', include('material.urls')),
     path('receipts/', include('receipts.urls')),
+    path('create-event/<str:proj>/', EventCreateView.as_view(), name='create-event'),
     path("schedule/", include("schedule.urls")),
     path('timecard/', include('timecard.urls')),
     path('todo/', include('todo.urls', namespace="todo")),


### PR DESCRIPTION
## Summary
- provide an `EventCreateView` in the schedule app
- expose a new `create-event/<proj>/` route so existing templates resolve properly

## Testing
- `python manage.py check` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_685639b3e7288332afd1e668d6da5e27