### PR TITLE
Make quick menu responsive

### DIFF
--- a/home/templates/home/home.html
+++ b/home/templates/home/home.html
@@ -183,7 +183,7 @@
 {% endif %}
 
 <!-- Dashboard Quick Menu -->
-<div class="row row-cols-2 row-cols-md-4 row-cols-xl-6 g-3 mb-4 dashboard-menu">
+<div class="row row-cols-2 row-cols-md-4 row-cols-xl-6 g-3 mb-4 dashboard-menu d-none d-md-flex">
     <div class="col">
         <a href="{% url 'project:project-list' %}" class="text-decoration-none">
             <div class="card text-center h-100">
@@ -274,6 +274,24 @@
             </div>
         </a>
     </div>
+</div>
+
+<!-- Quick Menu Dropdown for small screens -->
+<div class="dropdown mb-4 d-md-none">
+    <button class="btn btn-primary dropdown-toggle w-100" type="button" id="quickMenuDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+        Quick Menu
+    </button>
+    <ul class="dropdown-menu w-100" aria-labelledby="quickMenuDropdown">
+        <li><a class="dropdown-item" href="{% url 'project:project-list' %}"><i class="fas fa-wrench me-2 text-primary"></i>Projects</a></li>
+        <li><a class="dropdown-item" href="{% url 'location:location-list' %}"><i class="fas fa-building me-2 text-secondary"></i>Locations</a></li>
+        <li><a class="dropdown-item" href="{% url 'client:list' %}"><i class="fas fa-id-card me-2 text-info"></i>Clients</a></li>
+        <li><a class="dropdown-item" href="{% url 'asset:list' %}"><i class="fas fa-toolbox me-2 text-warning"></i>Assets</a></li>
+        <li><a class="dropdown-item" href="{% url 'hr:worker-list' %}"><i class="fas fa-users me-2 text-success"></i>Staff</a></li>
+        <li><a class="dropdown-item" href="{% url 'timecard:list' %}"><i class="fas fa-clock me-2 text-danger"></i>Time Cards</a></li>
+        <li><a class="dropdown-item" href="{% url 'todo:lists' %}"><i class="fas fa-tasks me-2 text-primary"></i>Todo</a></li>
+        <li><a class="dropdown-item" href="{% url 'receipts:list' %}"><i class="fas fa-receipt me-2 text-secondary"></i>Receipts</a></li>
+        <li><a class="dropdown-item" href="{% url 'wip:list' %}"><i class="fas fa-balance-scale me-2 text-warning"></i>WIP</a></li>
+    </ul>
 </div>
 
 <!-- Main Dashboard Row -->


### PR DESCRIPTION
## Summary
- hide quick menu card grid on small screens
- add dropdown quick menu for small screens

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68563a3d28108332bc5174b1d817f244