### PR TITLE
Fix missing static tag causing TemplateSyntaxError

### DIFF
--- a/project/templates/project/dashboard.html
+++ b/project/templates/project/dashboard.html
@@ -1,4 +1,5 @@
 {% extends "home/base.html" %}
+{% load static %}
 
 {% block title %}<title>Project Dashboard</title>{% endblock %}
 


### PR DESCRIPTION
## Summary
- load `static` in project dashboard template so static files resolve

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68563ef8cb2483329a06ea5caf351c44