### PR TITLE
Fix breadcrumbs to use correct home index URL

### DIFF
--- a/company/templates/company/base_company.html
+++ b/company/templates/company/base_company.html
@@ -99,7 +99,7 @@
 {% block breadcrumb %}
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb breadcrumb-modern">
-        <li class="breadcrumb-item"><a href="{% url 'home' %}"><i class="fas fa-home"></i> Home</a></li>
+        <li class="breadcrumb-item"><a href="{% url 'home:index' %}"><i class="fas fa-home"></i> Home</a></li>
         {% block company_breadcrumb %}
         <li class="breadcrumb-item"><a href="{% url 'company:list' %}">Companies</a></li>
         {% endblock %}

--- a/location/templates/location/dashboard.html
+++ b/location/templates/location/dashboard.html
@@ -13,7 +13,7 @@
 {% block breadcrumb %}
 <nav aria-label="breadcrumb" class="mb-4">
   <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
     <li class="breadcrumb-item active" aria-current="page">Location Dashboard</li>
   </ol>
 </nav>

--- a/location/templates/location/document_confirm_delete.html
+++ b/location/templates/location/document_confirm_delete.html
@@ -12,7 +12,7 @@
 {% block breadcrumb %}
 <nav aria-label="breadcrumb" class="mb-4">
   <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
     <li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
     <li class="breadcrumb-item"><a href="{{ object.location.get_absolute_url }}">{{ object.location.name }}</a></li>
     <li class="breadcrumb-item"><a href="{{ object.location.get_absolute_url }}#documents-tab">Documents</a></li>

--- a/location/templates/location/document_detail.html
+++ b/location/templates/location/document_detail.html
@@ -13,7 +13,7 @@
 {% block breadcrumb %}
 <nav aria-label="breadcrumb" class="mb-4">
   <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
     <li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
     <li class="breadcrumb-item"><a href="{{ document.location.get_absolute_url }}">{{ document.location.name }}</a></li>
     <li class="breadcrumb-item"><a href="{{ document.location.get_absolute_url }}#documents-tab">Documents</a></li>

--- a/location/templates/location/document_form.html
+++ b/location/templates/location/document_form.html
@@ -15,7 +15,7 @@
 {% block breadcrumb %}
 <nav aria-label="breadcrumb" class="mb-4">
   <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
     <li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
     <li class="breadcrumb-item"><a href="{{ location.get_absolute_url }}">{{ location.name }}</a></li>
     <li class="breadcrumb-item active" aria-current="page">

--- a/location/templates/location/document_list.html
+++ b/location/templates/location/document_list.html
@@ -13,7 +13,7 @@
 {% block breadcrumb %}
 <nav aria-label="breadcrumb" class="mb-4">
   <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
     <li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
     <li class="breadcrumb-item"><a href="{{ location.get_absolute_url }}">{{ location.name }}</a></li>
     <li class="breadcrumb-item active" aria-current="page">Documents</li>

--- a/location/templates/location/location_form.html
+++ b/location/templates/location/location_form.html
@@ -1171,7 +1171,7 @@ document.addEventListener('DOMContentLoaded', function() {
 {% block breadcrumb %}
 <nav aria-label="breadcrumb" class="mb-4">
   <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
     <li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
     <li class="breadcrumb-item"><a href="{% url 'location:location-list' %}">All Locations</a></li>
     {% if form.instance.pk %}

--- a/location/templates/location/location_list.html
+++ b/location/templates/location/location_list.html
@@ -13,7 +13,7 @@
 {% block breadcrumb %}
 <nav aria-label="breadcrumb" class="mb-4">
   <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
     <li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
     <li class="breadcrumb-item active" aria-current="page">All Locations</li>
   </ol>

--- a/location/templates/location/location_map.html
+++ b/location/templates/location/location_map.html
@@ -14,7 +14,7 @@
 {% block breadcrumb %}
 <nav aria-label="breadcrumb" class="mb-4">
   <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
     <li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
     <li class="breadcrumb-item active" aria-current="page">Map View</li>
   </ol>


### PR DESCRIPTION
## Summary
- fix breadcrumb links that referenced a non-existent `home` URL name

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68563f2a218c83328e1ccde79def77ce