### PR TITLE
Switch to WeasyPrint for PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a collection of Django applications for managing many a
 
 - Python 3.11+
 - Django 5.2
-- Additional packages listed in `wbee/settings/base.py` (e.g. `django-extensions`, `djangorestframework`, `django-filter`, `django-import-export`, `django-crispy-forms`, `crispy-bootstrap5`, `django-cors-headers`, `dj-database-url`, `python-decouple`, `Pillow`, `easy-thumbnails`, `django-mptt`, `bleach`, `pytest-django`, `django-grappelli`, `django-filer`, `whitenoise`, `redis`, `qrcode`, `pytz`, `psycopg2-binary`, `sentry-sdk`, `django-storages[boto3]`, `django-debug-toolbar`).
+- Additional packages listed in `wbee/settings/base.py` (e.g. `django-extensions`, `djangorestframework`, `django-filter`, `django-import-export`, `django-crispy-forms`, `crispy-bootstrap5`, `django-cors-headers`, `dj-database-url`, `python-decouple`, `Pillow`, `easy-thumbnails`, `django-mptt`, `bleach`, `pytest-django`, `django-grappelli`, `django-filer`, `whitenoise`, `redis`, `qrcode`, `pytz`, `psycopg2-binary`, `sentry-sdk`, `django-storages[boto3]`, `django-debug-toolbar`, `weasyprint`).
 - A database supported by Django (SQLite is fine for development).
 
 ## Environment Setup

--- a/project/render.py
+++ b/project/render.py
@@ -1,7 +1,8 @@
 from io import BytesIO
+
 from django.http import HttpResponse
 from django.template.loader import get_template
-import xhtml2pdf.pisa as pisa
+from weasyprint import HTML
 
 
 class Render:
@@ -10,9 +11,8 @@ class Render:
     def render(path: str, params: dict):
         template = get_template(path)
         html = template.render(params)
-        response = BytesIO()
-        pdf = pisa.pisaDocument(BytesIO(html.encode("UTF-8")), response)
-        if not pdf.err:
-            return HttpResponse(response.getvalue(), content_type='application/pdf')
-        else:
-            return HttpResponse("Error Rendering PDF", status=400)
+
+        # Use WeasyPrint to generate the PDF
+        pdf_bytes = HTML(string=html, base_url=".").write_pdf()
+
+        return HttpResponse(pdf_bytes, content_type="application/pdf")

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ psycopg2-binary
 sentry-sdk
 django-storages[boto3]
 django-debug-toolbar
+weasyprint


### PR DESCRIPTION
## Summary
- replace deprecated `xhtml2pdf` PDF rendering with `weasyprint`
- document new dependency
- update requirements list

## Testing
- `pip install -r requirements.txt`
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: helpdesk app not in INSTALLED_APPS)*

------
https://chatgpt.com/codex/tasks/task_e_68565b946f888332abb1e5acbd788239