### PR TITLE
Fix breadcrumbs for location list

### DIFF
--- a/location/templates/location/location_list.html
+++ b/location/templates/location/location_list.html
@@ -11,13 +11,8 @@
 {% endblock %}
 
 {% block breadcrumb %}
-<nav aria-label="breadcrumb" class="mb-4">
-  <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
-    <li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
-    <li class="breadcrumb-item active" aria-current="page">All Locations</li>
-  </ol>
-</nav>
+<li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
+<li class="breadcrumb-item active" aria-current="page">All Locations</li>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- fix breadcrumb block on location list

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: helpdesk app not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68565ea420788332a8090ea989409f5c