### PR TITLE
Fix breadcrumb markup in location dashboard

### DIFF
--- a/location/templates/location/location_dashboard.html
+++ b/location/templates/location/location_dashboard.html
@@ -2,7 +2,9 @@
 {% load static %}
 
 {% block title %}<title>Location Dashboard</title>{% endblock %}
-{% block breadcrumb %}/ <a href="{% url 'location:dashboard' %}">Location Dashboard</a>{% endblock %}
+{% block breadcrumb %}
+    <li class="breadcrumb-item active" aria-current="page">Location Dashboard</li>
+{% endblock %}
 
 {% block styler %}
 <link href="{% static 'home/vendor/datatables/dataTables.bootstrap4.css' %}" rel="stylesheet" type="text/css">


### PR DESCRIPTION
## Summary
- correct breadcrumb block in `location_dashboard.html`

## Testing
- `python -m pytest -q --ds=wbee.settings.settings_test` *(fails: Model class helpdesk.models.base.Queue doesn't declare an explicit app_label)*

------
https://chatgpt.com/codex/tasks/task_e_685663b22e788332aad39f3574390d62