### PR TITLE
Fix missing schedule index URL

### DIFF
--- a/schedule/urls.py
+++ b/schedule/urls.py
@@ -6,6 +6,8 @@ from . import views
 app_name = "schedule"
 
 urlpatterns = [
+    path("", views.CalendarListView.as_view(), name="schedule"),
+    path("calendars/", views.CalendarListView.as_view(), name="calendar_list"),
     path("<int:calendar_id>/ical/", CalendarICalendar(), name="calendar-ical"),
     path("event/create/<str:proj>/", views.EventCreateView.as_view(), name="create-event"),
     path("calendars/<slug:slug>/", views.CalendarDetailView.as_view(), name="calendar-detail"),

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.urls import reverse
-from django.views.generic import CreateView, DetailView
+from django.views.generic import CreateView, DetailView, ListView
 from django.shortcuts import get_object_or_404
 
 from .models import Event, Calendar
@@ -51,3 +51,11 @@ class CalendarDetailView(LoginRequiredMixin, DetailView):
             }
         )
         return context
+
+
+class CalendarListView(LoginRequiredMixin, ListView):
+    """Simple calendar list view to serve as schedule index."""
+
+    model = Calendar
+    template_name = "schedule/calendar_list.html"
+    # use default context object name "object_list" for compatibility


### PR DESCRIPTION
## Summary
- add a CalendarListView as the schedule index
- expose new view from URLs so templates using `{% url 'schedule' %}` resolve

## Testing
- `python manage.py check`
- `python manage.py test schedule`

------
https://chatgpt.com/codex/tasks/task_e_685664935e84833288c4a98324e0a308