### PR TITLE
Add schedule demo page

### DIFF
--- a/home/templates/home/schedule_example.html
+++ b/home/templates/home/schedule_example.html
@@ -1,0 +1,85 @@
+{% extends 'home/base.html' %}
+{% block title %}Schedule Demo{% endblock %}
+
+{% block breadcrumb %}
+<li class="breadcrumb-item active">Schedule Demo</li>
+{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col-lg-8">
+    <div class="card mb-3">
+      <div class="card-header">
+        <i class="fa fa-bell-o"></i> Scheduled events
+      </div>
+      <div class="list-group list-group-flush small">
+        <!-- Example items -->
+        <a class="list-group-item list-group-item-action" href="#">
+          <div class="media">
+            <div class="statusLost" style="background-color:#3b576c;">3159</div>
+            <div class="media-body">
+              <strong>April 28th</strong> Sun City Day 12: Screens <strong>Sun City Oro Valley AV</strong>.
+              <div class="text-muted smaller">site: 6 a.m.</div>
+            </div>
+          </div>
+        </a>
+        <a class="list-group-item list-group-item-action" href="#">
+          <div class="media">
+            <div class="statusLost" style="background-color:#eadd8c;">3159</div>
+            <div class="media-body">
+              <strong>April 27th</strong> Installing parts in 3 Rooms: Bring Parts <strong>Sun City Oro Valley AV</strong>.
+              <div class="text-muted smaller">site: 6 a.m.</div>
+            </div>
+          </div>
+        </a>
+        <a class="list-group-item list-group-item-action" href="#">
+          <div class="media">
+            <div class="statusLost" style="background-color:#70dd9c;">3022</div>
+            <div class="media-body">
+              <strong>July 02nd</strong> Test all buttons: Test and function <strong>Del Sol</strong>.
+              <div class="text-muted smaller">office: 8:30 a.m. - site: 10 a.m.</div>
+            </div>
+          </div>
+        </a>
+        <a class="list-group-item list-group-item-action" href="#">
+          <div class="media">
+            <div class="statusLost" style="background-color:#058989;">2832</div>
+            <div class="media-body">
+              <strong>April 29th</strong> Start of AVB install: Install <strong>Catalina Foothills Church</strong>.
+              <div class="text-muted smaller">site: 9 a.m.</div>
+            </div>
+          </div>
+        </a>
+        <a class="list-group-item list-group-item-action" href="#">
+          <div class="media">
+            <div class="statusLost" style="background-color:#599f90;">2772</div>
+            <div class="media-body">
+              <strong>Nov. 12th</strong> Speaker Hang: Meet at the school and continue <strong>Littleton Academy of Arts</strong>.
+              <div class="text-muted smaller">office: 6 a.m. - site: 8 a.m.</div>
+            </div>
+          </div>
+        </a>
+        <a class="list-group-item list-group-item-action" href="#">View full schedule...</a>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-4">
+    <div class="card mb-3">
+      <div class="card-header" style="background-color:rgb(0,119,255);">
+        <b>Tools</b>
+      </div>
+      <div class="list-group list-group-flush small">
+        <a class="list-group-item list-group-item-action" href="#">
+          <div class="media">
+            <div class="statusLost">Ladder</div>
+            <div class="media-body">
+              <strong>AV1200</strong> Location: Truck
+              <div class="text-muted smaller">Twelve Footer - Orange</div>
+            </div>
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/home/urls.py
+++ b/home/urls.py
@@ -12,6 +12,7 @@ app_name = 'home'
 urlpatterns = [
     # Main dashboard
     path('', views.index, name='index'),
+    path('schedule-demo/', views.schedule_demo, name='schedule-demo'),
     
     # Contact functionality
     path('contact/', views.contactView, name='contact'),

--- a/home/views.py
+++ b/home/views.py
@@ -521,3 +521,9 @@ def successView(request):
     return render(request, 'home/success.html', {
         'message': 'Success! Thank you for your message.'
     })
+
+
+def schedule_demo(request):
+    """Simple demo view showing scheduled events snippet."""
+    return render(request, "home/schedule_example.html")
+


### PR DESCRIPTION
## Summary
- add a demo template with scheduled events and tools listing
- expose a new `schedule-demo` URL
- implement simple view for the demo

## Testing
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_685665010a788332b0dcaa7f7e04f34e