### PR TITLE
Fix admin event duration calc when times missing

### DIFF
--- a/schedule/schedule_models.py
+++ b/schedule/schedule_models.py
@@ -580,7 +580,9 @@ class Event(TimeStampedModel):
     @property
     def duration(self):
         """Get event duration as timedelta"""
-        return self.end - self.start
+        if self.start and self.end:
+            return self.end - self.start
+        return timedelta()
 
     @property
     def duration_hours(self):
@@ -814,7 +816,9 @@ class Occurrence(TimeStampedModel):
     @property
     def duration(self):
         """Get occurrence duration"""
-        return self.end - self.start
+        if self.start and self.end:
+            return self.end - self.start
+        return timedelta()
 
     @property
     def duration_hours(self):


### PR DESCRIPTION
## Summary
- handle missing start or end timestamps when calculating duration for Events and Occurrences
- run automated tests (failures in helpdesk app)

## Testing
- `pip install -r requirements.txt`
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: helpdesk module not configured)*

------
https://chatgpt.com/codex/tasks/task_e_685666cdac348332a3fcafb437560fa0