### PR TITLE
Add top client highlighting

### DIFF
--- a/client/templates/client/client_list.html
+++ b/client/templates/client/client_list.html
@@ -127,6 +127,16 @@
     color: white;
     transform: translateY(-1px);
   }
+
+  .top-client {
+    border: 2px solid #ffd700;
+    box-shadow: 0 0 15px rgba(255,215,0,0.5);
+  }
+
+  .top-client-icon {
+    color: #ffd700;
+    margin-right: 4px;
+  }
 </style>
 {% endblock %}
 
@@ -241,6 +251,11 @@
       </a>
     </li>
     <li class="nav-item">
+      <a class="nav-link" href="#" data-filter="top">
+        <i class="fas fa-star text-warning me-1"></i>Top Clients
+      </a>
+    </li>
+    <li class="nav-item">
       <a class="nav-link" href="#" data-filter="inactive">
         <span class="status-indicator status-inactive"></span>Inactive
       </a>
@@ -251,8 +266,8 @@
   <div id="cardViewContainer">
     <div class="row" id="clientCards">
       {% for client in client_list %}
-      <div class="col-xl-4 col-lg-6 col-md-6 mb-4 client-item" data-status="{{ client.status }}">
-        <div class="card client-card h-100">
+      <div class="col-xl-4 col-lg-6 col-md-6 mb-4 client-item" data-status="{{ client.status }}"{% if client.total_revenue and client.total_revenue > 1000000 %} data-top="true"{% endif %}>
+        <div class="card client-card h-100{% if client.total_revenue and client.total_revenue > 1000000 %} top-client{% endif %}">
           <div class="card-body">
             <div class="d-flex align-items-start mb-3">
               <div class="me-3">
@@ -266,6 +281,9 @@
               </div>
               <div class="flex-grow-1">
                 <h6 class="card-title mb-1">
+                  {% if client.total_revenue and client.total_revenue > 1000000 %}
+                    <i class="fas fa-star top-client-icon" title="Top Client"></i>
+                  {% endif %}
                   <a href="{{ client.get_absolute_url }}" class="text-decoration-none text-dark font-weight-bold">
                     {{ client.company_name }}
                   </a>
@@ -399,7 +417,7 @@
             </thead>
             <tbody>
               {% for client in client_list %}
-              <tr class="client-row" data-status="{{ client.status }}">
+              <tr class="client-row" data-status="{{ client.status }}"{% if client.total_revenue and client.total_revenue > 1000000 %} data-top="true"{% endif %}>
                 <td>
                   <div class="d-flex align-items-center">
                     {% if client.logo %}
@@ -410,6 +428,9 @@
                       </div>
                     {% endif %}
                     <div>
+                      {% if client.total_revenue and client.total_revenue > 1000000 %}
+                        <i class="fas fa-star top-client-icon" title="Top Client"></i>
+                      {% endif %}
                       <a href="{{ client.get_absolute_url }}" class="font-weight-bold text-decoration-none">
                         {{ client.company_name }}
                       </a>
@@ -542,6 +563,9 @@ $(document).ready(function() {
     // Filter cards
     if (filter === 'all') {
       $('.client-item, .client-row').show();
+    } else if (filter === 'top') {
+      $('.client-item, .client-row').hide();
+      $('[data-top="true"]').show();
     } else {
       $('.client-item, .client-row').hide();
       $(`.client-item[data-status="${filter}"], .client-row[data-status="${filter}"]`).show();


### PR DESCRIPTION
## Summary
- style: add highlight for top clients in list
- feat: add "Top Clients" filter and star icons for high revenue clients

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'six')*

------
https://chatgpt.com/codex/tasks/task_e_6856688201608332b96030d5bb420b58