### PR TITLE
Improve project dashboard and material pages

### DIFF
--- a/project/templates/project/dashboard.html
+++ b/project/templates/project/dashboard.html
@@ -1,54 +1,99 @@
 {% extends "home/base.html" %}
-{% load static %}
-
 {% block title %}<title>Project Dashboard</title>{% endblock %}
-
-{% block extra_css %}
-<link rel="stylesheet" href="{% static 'project/css/dashboard.css' %}">
-{% endblock %}
-
 {% block breadcrumb %}
 <li class="breadcrumb-item active">Projects</li>
 {% endblock %}
-
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
   <h1 class="h3 mb-0">Project Dashboard</h1>
-  <a href="{% url 'project:project-create' %}" class="btn btn-primary">
-    <i class="fas fa-plus"></i> New Project
-  </a>
+  <a href="{% url 'project:project-create' %}" class="btn btn-primary"><i class="fas fa-plus"></i> New Project</a>
 </div>
-
-<div class="row dashboard-links">
-  <div class="col-md-4 mb-3">
-    <a href="{% url 'project:project-list' %}" class="text-decoration-none text-reset">
-      <div class="card h-100 shadow-sm">
-        <div class="card-body text-center">
-          <i class="fas fa-list fa-2x mb-2"></i>
-          <h5 class="card-title mb-0">All Projects</h5>
-        </div>
+<div class="row mb-4">
+  <div class="col-md-3 mb-3">
+    <div class="card border-left-primary shadow h-100 py-2">
+      <div class="card-body">
+        <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Total Projects</div>
+        <div class="h5 mb-0 font-weight-bold text-gray-800">{{ project_stats.total_projects }}</div>
       </div>
+    </div>
+  </div>
+  <div class="col-md-3 mb-3">
+    <div class="card border-left-success shadow h-100 py-2">
+      <div class="card-body">
+        <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Active</div>
+        <div class="h5 mb-0 font-weight-bold text-gray-800">{{ project_stats.active_projects }}</div>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-3 mb-3">
+    <div class="card border-left-info shadow h-100 py-2">
+      <div class="card-body">
+        <div class="text-xs font-weight-bold text-info text-uppercase mb-1">Completed</div>
+        <div class="h5 mb-0 font-weight-bold text-gray-800">{{ project_stats.completed_projects }}</div>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-3 mb-3">
+    <div class="card border-left-danger shadow h-100 py-2">
+      <div class="card-body">
+        <div class="text-xs font-weight-bold text-danger text-uppercase mb-1">Overdue</div>
+        <div class="h5 mb-0 font-weight-bold text-gray-800">{{ project_stats.overdue_projects }}</div>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-lg-6 mb-4">
+    <div class="card shadow">
+      <div class="card-header py-3 d-flex flex-row align-items-center justify-content-between">
+        <h6 class="m-0 font-weight-bold text-primary">Recent Projects</h6>
+        <a href="{% url 'project:project-list' %}" class="btn btn-sm btn-outline-primary">View All</a>
+      </div>
+      <div class="card-body">
+        {% if recent_projects %}
+        <ul class="list-group list-group-flush">
+          {% for p in recent_projects %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <a href="{% url 'project:project-detail' p.job_number %}">{{ p.job_number }} - {{ p.name }}</a>
+            <span class="badge bg-secondary">{{ p.status }}</span>
+          </li>
+          {% endfor %}
+        </ul>
+        {% else %}
+        <p class="text-muted">No recent projects.</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-6 mb-4">
+    <div class="card shadow">
+      <div class="card-header py-3">
+        <h6 class="m-0 font-weight-bold text-primary">Upcoming Milestones</h6>
+      </div>
+      <div class="card-body">
+        {% if upcoming_milestones %}
+        <ul class="list-group list-group-flush">
+          {% for m in upcoming_milestones %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <span>{{ m.project.job_number }} - {{ m.name }}</span>
+            <span>{{ m.target_date|date:"M d" }}</span>
+          </li>
+          {% endfor %}
+        </ul>
+        {% else %}
+        <p class="text-muted">No upcoming milestones.</p>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+<div class="row">
+  {% for action in quick_actions %}
+  <div class="col-md-3 mb-3 text-center">
+    <a href="{{ action.url }}" class="btn btn-outline-secondary w-100">
+      <i class="fa {{ action.icon }}"></i><br>{{ action.title }}
     </a>
   </div>
-  <div class="col-md-4 mb-3">
-    <a href="{% url 'project:active-projects' %}" class="text-decoration-none text-reset">
-      <div class="card h-100 shadow-sm">
-        <div class="card-body text-center">
-          <i class="fas fa-play fa-2x mb-2"></i>
-          <h5 class="card-title mb-0">Active Projects</h5>
-        </div>
-      </div>
-    </a>
-  </div>
-  <div class="col-md-4 mb-3">
-    <a href="{% url 'project:reports' %}" class="text-decoration-none text-reset">
-      <div class="card h-100 shadow-sm">
-        <div class="card-body text-center">
-          <i class="fas fa-chart-line fa-2x mb-2"></i>
-          <h5 class="card-title mb-0">Reports</h5>
-        </div>
-      </div>
-    </a>
-  </div>
+  {% endfor %}
 </div>
 {% endblock %}

--- a/project/templates/project/device_confirm_delete.html
+++ b/project/templates/project/device_confirm_delete.html
@@ -1,7 +1,19 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}<title>Delete {{ material_type }}</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'project:project-detail' object.project.job_number %}">{{ object.project.job_number }}</a></li>
+<li class="breadcrumb-item"><a href="{% url list_url_name object.project.job_number %}">{{ material_type }}s</a></li>
+<li class="breadcrumb-item active">Delete</li>
+{% endblock %}
 {% block content %}
-<div class="alert alert-warning mt-4">
-  This feature is not yet implemented.
+<div class="card shadow">
+  <div class="card-body">
+    <p>Are you sure you want to delete this {{ material_type|lower }}?</p>
+    <form method="post">
+      {% csrf_token %}
+      <a href="{% url list_url_name object.project.job_number %}" class="btn btn-secondary">Cancel</a>
+      <button type="submit" class="btn btn-danger">Delete</button>
+    </form>
+  </div>
 </div>
 {% endblock %}

--- a/project/templates/project/device_detail.html
+++ b/project/templates/project/device_detail.html
@@ -1,7 +1,26 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% load humanize %}
+{% block title %}<title>{{ material_type }} Detail</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'project:project-detail' object.project.job_number %}">{{ object.project.job_number }}</a></li>
+<li class="breadcrumb-item"><a href="{% url list_url_name object.project.job_number %}">{{ material_type }}s</a></li>
+<li class="breadcrumb-item active">Detail</li>
+{% endblock %}
 {% block content %}
-<div class="alert alert-warning mt-4">
-  This feature is not yet implemented.
+<div class="card">
+  <div class="card-header"><h5 class="mb-0">{{ material_type }} Details</h5></div>
+  <div class="card-body">
+    <dl class="row">
+      <dt class="col-sm-3">Product</dt><dd class="col-sm-9">{{ object.product }}</dd>
+      <dt class="col-sm-3">Quantity</dt><dd class="col-sm-9">{{ object.quantity }}</dd>
+      <dt class="col-sm-3">Unit Cost</dt><dd class="col-sm-9">${{ object.unit_cost|floatformat:2 }}</dd>
+      <dt class="col-sm-3">Total</dt><dd class="col-sm-9">${{ object.total|floatformat:2 }}</dd>
+      <dt class="col-sm-3">Status</dt><dd class="col-sm-9">{{ object.status }}</dd>
+      <dt class="col-sm-3">Delivered</dt><dd class="col-sm-9">{{ object.delivered_date|date:'M d, Y' }}</dd>
+      <dt class="col-sm-3">Installed</dt><dd class="col-sm-9">{{ object.installed_date|date:'M d, Y' }}</dd>
+    </dl>
+    <a href="{% url edit_url_name object.pk %}" class="btn btn-primary">Edit</a>
+    <a href="{% url delete_url_name object.pk %}" class="btn btn-danger">Delete</a>
+  </div>
 </div>
 {% endblock %}

--- a/project/templates/project/device_form.html
+++ b/project/templates/project/device_form.html
@@ -1,7 +1,27 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}<title>{% if form.instance.pk %}Edit {{ material_type }}{% else %}Add {{ material_type }}{% endif %}</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'project:project-detail' project.job_number %}">{{ project.job_number }}</a></li>
+<li class="breadcrumb-item"><a href="{% url list_url_name project.job_number %}">{{ material_type }}s</a></li>
+<li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Add{% endif %}</li>
+{% endblock %}
 {% block content %}
-<div class="alert alert-warning mt-4">
-  This feature is not yet implemented.
+<div class="row justify-content-center">
+  <div class="col-lg-8">
+    <div class="card shadow">
+      <div class="card-header">
+        <h6 class="m-0 font-weight-bold text-primary">{% if form.instance.pk %}Edit {{ material_type }}{% else %}Add {{ material_type }}{% endif %}</h6>
+      </div>
+      <div class="card-body">
+        <form method="post" enctype="multipart/form-data">
+          {% csrf_token %}
+          {{ form.as_p }}
+          <div class="text-end">
+            <button type="submit" class="btn btn-primary">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/project/templates/project/device_list.html
+++ b/project/templates/project/device_list.html
@@ -1,7 +1,42 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% load humanize %}
+{% block title %}<title>{{ material_type }}s - {{ project.name }}</title>{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'project:project-detail' project.job_number %}">{{ project.job_number }}</a></li>
+<li class="breadcrumb-item active">{{ material_type }}s</li>
+{% endblock %}
 {% block content %}
-<div class="alert alert-warning mt-4">
-  This feature is not yet implemented.
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="h3 mb-0">{{ material_type }}s for {{ project.name }}</h1>
+  <a href="{{ create_url }}" class="btn btn-primary"><i class="fas fa-plus"></i> Add {{ material_type }}</a>
 </div>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Product</th>
+      <th>Quantity</th>
+      <th class="text-end">Unit Cost</th>
+      <th class="text-end">Total</th>
+      <th>Status</th>
+      <th class="text-end"></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in materials %}
+    <tr>
+      <td>{{ item.product }}</td>
+      <td>{{ item.quantity }}</td>
+      <td class="text-end">${{ item.unit_cost|floatformat:2 }}</td>
+      <td class="text-end">${{ item.total|floatformat:2 }}</td>
+      <td>{{ item.status }}</td>
+      <td class="text-end">
+        <a href="{% url edit_url_name item.pk %}" class="btn btn-sm btn-outline-secondary">Edit</a>
+        <a href="{% url delete_url_name item.pk %}" class="btn btn-sm btn-outline-danger">Delete</a>
+      </td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="6" class="text-center text-muted">No {{ material_type|lower }}s added.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
 {% endblock %}

--- a/project/views.py
+++ b/project/views.py
@@ -1262,6 +1262,11 @@ class ScopeOfWorkListView(ProjectAccessMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['project'] = self.project
+        context['materials'] = self.object_list
+        context['material_type'] = 'Device'
+        context['create_url'] = reverse('project:device-create', kwargs={'job_number': self.project.job_number})
+        context['edit_url_name'] = 'project:device-edit'
+        context['delete_url_name'] = 'project:device-delete'
         return context
 
 class ScopeOfWorkCreateView(ProjectAccessMixin, CreateView):
@@ -1400,6 +1405,14 @@ class ProjectDeviceDetailView(DetailView):
     template_name = 'project/device_detail.html'
     context_object_name = 'device_item'
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['material_type'] = 'Device'
+        context['list_url_name'] = 'project:device-list'
+        context['edit_url_name'] = 'project:device-edit'
+        context['delete_url_name'] = 'project:device-delete'
+        return context
+
 class ProjectDeviceUpdateView(UpdateView):
     """Update project device"""
     model = ProjectMaterial
@@ -1418,9 +1431,15 @@ class ProjectDeviceDeleteView(DeleteView):
     """Delete project device"""
     model = ProjectMaterial
     template_name = 'project/device_confirm_delete.html'
-    
+
     def get_success_url(self):
         return reverse('project:device-list', kwargs={'job_number': self.object.project.job_number})
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['material_type'] = 'Device'
+        context['list_url_name'] = 'project:device-list'
+        return context
 
 # Additional material views for hardware, software, licenses, and travel
 
@@ -1437,6 +1456,11 @@ class ProjectHardwareListView(ProjectAccessMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['project'] = self.project
+        context['materials'] = self.object_list
+        context['material_type'] = 'Hardware'
+        context['create_url'] = reverse('project:hardware-create', kwargs={'job_number': self.project.job_number})
+        context['edit_url_name'] = 'project:hardware-edit'
+        context['delete_url_name'] = 'project:hardware-delete'
         return context
 
 class ProjectHardwareCreateView(ProjectAccessMixin, CreateView):
@@ -1454,6 +1478,34 @@ class ProjectHardwareCreateView(ProjectAccessMixin, CreateView):
         kwargs['proj'] = self.project.job_number
         return kwargs
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['project'] = self.project
+        context['material_type'] = 'Travel'
+        context['list_url_name'] = 'project:travel-list'
+        return context
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['project'] = self.project
+        context['material_type'] = 'License'
+        context['list_url_name'] = 'project:license-list'
+        return context
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['project'] = self.project
+        context['material_type'] = 'Software'
+        context['list_url_name'] = 'project:software-list'
+        return context
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['project'] = self.project
+        context['material_type'] = 'Hardware'
+        context['list_url_name'] = 'project:hardware-list'
+        return context
+
     def form_valid(self, form):
         form.instance.project = self.project
         form.instance.material_type = 'hardware'
@@ -1468,6 +1520,14 @@ class ProjectHardwareDetailView(DetailView):
     template_name = 'project/device_detail.html'
     context_object_name = 'hardware_item'
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['material_type'] = 'Hardware'
+        context['list_url_name'] = 'project:hardware-list'
+        context['edit_url_name'] = 'project:hardware-edit'
+        context['delete_url_name'] = 'project:hardware-delete'
+        return context
+
 class ProjectHardwareUpdateView(UpdateView):
     """Update project hardware"""
     model = ProjectMaterial
@@ -1479,6 +1539,34 @@ class ProjectHardwareUpdateView(UpdateView):
         kwargs['proj'] = self.object.project.job_number
         return kwargs
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['project'] = self.object.project
+        context['material_type'] = 'Travel'
+        context['list_url_name'] = 'project:travel-list'
+        return context
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['project'] = self.object.project
+        context['material_type'] = 'License'
+        context['list_url_name'] = 'project:license-list'
+        return context
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['project'] = self.object.project
+        context['material_type'] = 'Software'
+        context['list_url_name'] = 'project:software-list'
+        return context
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['project'] = self.object.project
+        context['material_type'] = 'Hardware'
+        context['list_url_name'] = 'project:hardware-list'
+        return context
+
     def get_success_url(self):
         return reverse('project:hardware-list', kwargs={'job_number': self.object.project.job_number})
 
@@ -1489,6 +1577,12 @@ class ProjectHardwareDeleteView(DeleteView):
 
     def get_success_url(self):
         return reverse('project:hardware-list', kwargs={'job_number': self.object.project.job_number})
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['material_type'] = 'Hardware'
+        context['list_url_name'] = 'project:hardware-list'
+        return context
 
 
 class ProjectSoftwareListView(ProjectAccessMixin, ListView):
@@ -1504,6 +1598,11 @@ class ProjectSoftwareListView(ProjectAccessMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['project'] = self.project
+        context['materials'] = self.object_list
+        context['material_type'] = 'Software'
+        context['create_url'] = reverse('project:software-create', kwargs={'job_number': self.project.job_number})
+        context['edit_url_name'] = 'project:software-edit'
+        context['delete_url_name'] = 'project:software-delete'
         return context
 
 class ProjectSoftwareCreateView(ProjectAccessMixin, CreateView):
@@ -1535,6 +1634,14 @@ class ProjectSoftwareDetailView(DetailView):
     template_name = 'project/device_detail.html'
     context_object_name = 'software_item'
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['material_type'] = 'Software'
+        context['list_url_name'] = 'project:software-list'
+        context['edit_url_name'] = 'project:software-edit'
+        context['delete_url_name'] = 'project:software-delete'
+        return context
+
 class ProjectSoftwareUpdateView(UpdateView):
     """Update project software"""
     model = ProjectMaterial
@@ -1557,6 +1664,12 @@ class ProjectSoftwareDeleteView(DeleteView):
     def get_success_url(self):
         return reverse('project:software-list', kwargs={'job_number': self.object.project.job_number})
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['material_type'] = 'Software'
+        context['list_url_name'] = 'project:software-list'
+        return context
+
 
 class ProjectLicenseListView(ProjectAccessMixin, ListView):
     """List project licenses"""
@@ -1571,6 +1684,11 @@ class ProjectLicenseListView(ProjectAccessMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['project'] = self.project
+        context['materials'] = self.object_list
+        context['material_type'] = 'License'
+        context['create_url'] = reverse('project:license-create', kwargs={'job_number': self.project.job_number})
+        context['edit_url_name'] = 'project:license-edit'
+        context['delete_url_name'] = 'project:license-delete'
         return context
 
 class ProjectLicenseCreateView(ProjectAccessMixin, CreateView):
@@ -1602,6 +1720,14 @@ class ProjectLicenseDetailView(DetailView):
     template_name = 'project/device_detail.html'
     context_object_name = 'license_item'
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['material_type'] = 'License'
+        context['list_url_name'] = 'project:license-list'
+        context['edit_url_name'] = 'project:license-edit'
+        context['delete_url_name'] = 'project:license-delete'
+        return context
+
 class ProjectLicenseUpdateView(UpdateView):
     """Update project license"""
     model = ProjectMaterial
@@ -1624,6 +1750,12 @@ class ProjectLicenseDeleteView(DeleteView):
     def get_success_url(self):
         return reverse('project:license-list', kwargs={'job_number': self.object.project.job_number})
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['material_type'] = 'License'
+        context['list_url_name'] = 'project:license-list'
+        return context
+
 
 class ProjectTravelListView(ProjectAccessMixin, ListView):
     """List project travel items"""
@@ -1638,6 +1770,11 @@ class ProjectTravelListView(ProjectAccessMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['project'] = self.project
+        context['materials'] = self.object_list
+        context['material_type'] = 'Travel'
+        context['create_url'] = reverse('project:travel-create', kwargs={'job_number': self.project.job_number})
+        context['edit_url_name'] = 'project:travel-edit'
+        context['delete_url_name'] = 'project:travel-delete'
         return context
 
 class ProjectTravelCreateView(ProjectAccessMixin, CreateView):
@@ -1669,6 +1806,14 @@ class ProjectTravelDetailView(DetailView):
     template_name = 'project/device_detail.html'
     context_object_name = 'travel_item'
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['material_type'] = 'Travel'
+        context['list_url_name'] = 'project:travel-list'
+        context['edit_url_name'] = 'project:travel-edit'
+        context['delete_url_name'] = 'project:travel-delete'
+        return context
+
 class ProjectTravelUpdateView(UpdateView):
     """Update travel item"""
     model = ProjectMaterial
@@ -1690,6 +1835,12 @@ class ProjectTravelDeleteView(DeleteView):
 
     def get_success_url(self):
         return reverse('project:travel-list', kwargs={'job_number': self.object.project.job_number})
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['material_type'] = 'Travel'
+        context['list_url_name'] = 'project:travel-list'
+        return context
 
 # ============================================
 # Project Changes and Milestones


### PR DESCRIPTION
## Summary
- overhaul project dashboard to show stats, recent projects, milestones and actions
- implement generic material pages (`device_list.html`, etc.)
- wire up context data in project material views

## Testing
- `pip install -r requirements.txt`
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: helpdesk app missing)*

------
https://chatgpt.com/codex/tasks/task_e_685667cfae0c8332858557b881221333