### PR TITLE
Improve page titles

### DIFF
--- a/helpdesk/templates/helpdesk/base.html
+++ b/helpdesk/templates/helpdesk/base.html
@@ -15,7 +15,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title>{% block helpdesk_title %}Helpdesk{% endblock %} :: {% trans "Powered by django-helpdesk" %}</title>
+    <title>{% block title %}{% block helpdesk_title %}Helpdesk{% endblock %}{% endblock %} :: {% trans "Powered by django-helpdesk" %}</title>
 
     <!-- Bootstrap Core CSS -->
     {% if helpdesk_settings.HELPDESK_USE_CDN %}

--- a/helpdesk/templates/helpdesk/public_base.html
+++ b/helpdesk/templates/helpdesk/public_base.html
@@ -13,7 +13,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title>{% block helpdesk_title %}{% trans 'Helpdesk' %}{% endblock %}</title>
+    <title>{% block title %}{% block helpdesk_title %}{% trans 'Helpdesk' %}{% endblock %}{% endblock %}</title>
 
     <!-- Bootstrap Core CSS -->
     {% if helpdesk_settings.HELPDESK_USE_CDN %}

--- a/home/templates/home/base.html
+++ b/home/templates/home/base.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}WBEE Manager{% endblock %}</title>
+    <title>{% block title %}Wbee Appware{% endblock %}</title>
     
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="description" content="">
     <meta name="author" content="Mark Otto, Jacob Thornton, and Bootstrap contributors">
     <meta name="generator" content="Jekyll v3.8.5">
-    <title>Orginize · Wbee.app</title>
+    <title>Wbee Appware</title>
 
     <link rel="canonical" href="https://getbootstrap.com/docs/4.3/examples/product/">
 


### PR DESCRIPTION
## Summary
- update main site title
- nest helpdesk titles inside `title` block
- tweak landing page title

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: connection to postgres refused)*

------
https://chatgpt.com/codex/tasks/task_e_68566a6f319c83329010149205c18712