### PR TITLE
Refactor inline CSS into static files

### DIFF
--- a/asset/templates/asset/asset_list.html
+++ b/asset/templates/asset/asset_list.html
@@ -11,35 +11,6 @@
 
 {% block styler %}
 <link href="{% static 'home/css/asset-management.css' %}" rel="stylesheet" type="text/css">
-<style>
-    .table-actions {
-        min-width: 200px;
-    }
-    .condition-indicator {
-        width: 12px;
-        height: 12px;
-        border-radius: 50%;
-        display: inline-block;
-        margin-right: 5px;
-    }
-    .pagination-container {
-        display: flex;
-        justify-content: between;
-        align-items: center;
-        margin-top: 20px;
-    }
-    .bulk-actions {
-        background: #e3f2fd;
-        border-radius: 8px;
-        padding: 15px;
-        margin-bottom: 20px;
-        display: none;
-    }
-    .btn-outline-custom {
-        border: 2px solid;
-        font-weight: 500;
-    }
-</style>
 {% endblock %}
 
 {% block content %}

--- a/asset/templates/asset/asset_list2.html
+++ b/asset/templates/asset/asset_list2.html
@@ -6,73 +6,7 @@
     <title>Asset List - Asset Manager</title>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.0/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
-    <style>
-        .asset-card {
-            transition: transform 0.2s ease-in-out;
-            border: none;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-        }
-        .asset-card:hover {
-            transform: translateY(-3px);
-            box-shadow: 0 4px 15px rgba(0,0,0,0.2);
-        }
-        .status-badge {
-            font-size: 0.75rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-        .asset-image {
-            width: 60px;
-            height: 60px;
-            object-fit: cover;
-            border-radius: 8px;
-        }
-        .filter-section {
-            background: #f8f9fa;
-            border-radius: 10px;
-            padding: 20px;
-            margin-bottom: 20px;
-        }
-        .search-box {
-            border-radius: 25px;
-            padding-left: 45px;
-        }
-        .search-icon {
-            position: absolute;
-            left: 15px;
-            top: 50%;
-            transform: translateY(-50%);
-            color: #6c757d;
-        }
-        .table-actions {
-            min-width: 200px;
-        }
-        .condition-indicator {
-            width: 12px;
-            height: 12px;
-            border-radius: 50%;
-            display: inline-block;
-            margin-right: 5px;
-        }
-        .pagination-container {
-            display: flex;
-            justify-content: between;
-            align-items: center;
-            margin-top: 20px;
-        }
-        .bulk-actions {
-            background: #e3f2fd;
-            border-radius: 8px;
-            padding: 15px;
-            margin-bottom: 20px;
-            display: none;
-        }
-        .btn-outline-custom {
-            border: 2px solid;
-            font-weight: 500;
-        }
-    </style>
+    <link href="{% static 'home/css/asset-management.css' %}" rel="stylesheet">
 </head>
 <body class="bg-light">
     <!-- Navigation -->

--- a/home/templates/home/base.html
+++ b/home/templates/home/base.html
@@ -9,18 +9,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <link href="{% static 'home/css/sb-admin.css' %}" rel="stylesheet">
-    <style>
-        .breadcrumb-modern {
-            background: none;
-            padding: 0;
-            margin-bottom: 1rem;
-        }
-
-        .breadcrumb-modern .breadcrumb-item + .breadcrumb-item::before {
-            content: ">";
-            color: #6c757d;
-        }
-    </style>
+    <link href="{% static 'home/css/base.css' %}" rel="stylesheet">
     {% block extra_css %}{% endblock %}
 </head>
 <body>
@@ -87,11 +76,7 @@
 
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script>
-        $(document).ready(function() {
-            setTimeout(function() { $('.alert').fadeOut(); }, 5000);
-        });
-    </script>
+    <script src="{% static 'home/js/messages.js' %}"></script>
     {% block extra_js %}{% endblock %}
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,22 +13,7 @@
     <!-- Bootstrap core CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" >
 
-    <style>
-      .bd-placeholder-img {
-        font-size: 1.125rem;
-        text-anchor: middle;
-        -webkit-user-select: none;
-        -moz-user-select: none;
-        -ms-user-select: none;
-        user-select: none;
-      }
-
-      @media (min-width: 768px) {
-        .bd-placeholder-img-lg {
-          font-size: 3.5rem;
-        }
-      }
-    </style>
+    <link rel="stylesheet" href="static/home/css/index-custom.css">
     <!-- Custom styles for this template -->
     <link href="https://getbootstrap.com/docs/4.3/examples/product/product.css" rel="stylesheet">
   </head>

--- a/static/home/css/base.css
+++ b/static/home/css/base.css
@@ -1,0 +1,13 @@
+/* ============================================
+   Styles extracted from home/templates/home/base.html
+   ============================================ */
+.breadcrumb-modern {
+    background: none;
+    padding: 0;
+    margin-bottom: 1rem;
+}
+
+.breadcrumb-modern .breadcrumb-item + .breadcrumb-item::before {
+    content: ">";
+    color: #6c757d;
+}

--- a/static/home/css/index-custom.css
+++ b/static/home/css/index-custom.css
@@ -1,0 +1,17 @@
+/* ============================================
+   Custom styles extracted from index.html
+   ============================================ */
+.bd-placeholder-img {
+  font-size: 1.125rem;
+  text-anchor: middle;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+@media (min-width: 768px) {
+  .bd-placeholder-img-lg {
+    font-size: 3.5rem;
+  }
+}

--- a/static/home/js/messages.js
+++ b/static/home/js/messages.js
@@ -1,0 +1,6 @@
+/* ============================================
+   Generic message helpers
+   ============================================ */
+$(document).ready(function() {
+    setTimeout(function() { $('.alert').fadeOut(); }, 5000);
+});


### PR DESCRIPTION
## Summary
- move bootstrap example styles into `index-custom.css`
- extract breadcrumb CSS into `base.css`
- add generic fade-out message JS
- reference new assets from templates
- remove redundant inline CSS from asset templates

## Testing
- `pip install -r requirements.txt`
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: helpdesk app missing)*

------
https://chatgpt.com/codex/tasks/task_e_68566c97814c83328b60e9c940cf54dd