### PR TITLE
Fix universal title

### DIFF
--- a/helpdesk/templates/helpdesk/base.html
+++ b/helpdesk/templates/helpdesk/base.html
@@ -15,7 +15,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title>{% block title %}{% block helpdesk_title %}Helpdesk{% endblock %}{% endblock %} :: {% trans "Powered by django-helpdesk" %}</title>
+    <title>{% block title %}{% block helpdesk_title %}{{ SITE_TITLE }}{% endblock %}{% endblock %} :: {% trans "Powered by django-helpdesk" %}</title>
 
     <!-- Bootstrap Core CSS -->
     {% if helpdesk_settings.HELPDESK_USE_CDN %}

--- a/helpdesk/templates/helpdesk/help_base.html
+++ b/helpdesk/templates/helpdesk/help_base.html
@@ -36,7 +36,7 @@
             padding-left: 2em;
         }
         </style>
-        <title>{% block title %}django-helpdesk Help{% endblock %}</title>
+        <title>{% block title %}{{ SITE_TITLE }} Help{% endblock %}</title>
     </head>
     <body>
         <h1>{% block heading %}django-helpdesk Help{% endblock %}</h1>

--- a/helpdesk/templates/helpdesk/public_base.html
+++ b/helpdesk/templates/helpdesk/public_base.html
@@ -13,7 +13,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title>{% block title %}{% block helpdesk_title %}{% trans 'Helpdesk' %}{% endblock %}{% endblock %}</title>
+    <title>{% block title %}{% block helpdesk_title %}{{ SITE_TITLE }}{% endblock %}{% endblock %}</title>
 
     <!-- Bootstrap Core CSS -->
     {% if helpdesk_settings.HELPDESK_USE_CDN %}

--- a/home/templates/home/base.html
+++ b/home/templates/home/base.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}Wbee Appware{% endblock %}</title>
+    <title>{% block title %}{{ SITE_TITLE }}{% endblock %}</title>
     
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="description" content="">
     <meta name="author" content="Mark Otto, Jacob Thornton, and Bootstrap contributors">
     <meta name="generator" content="Jekyll v3.8.5">
-    <title>Wbee Appware</title>
+    <title>WBEE Universal Company Manager</title>
 
     <link rel="canonical" href="https://getbootstrap.com/docs/4.3/examples/product/">
 

--- a/schedule/templates/fullcalendar.html
+++ b/schedule/templates/fullcalendar.html
@@ -1,7 +1,7 @@
 {% extends 'home/base.html' %}
 {% load i18n %}
 
-{% block title %}<title>Wbee Appware</title>{% endblock %}
+{% block title %}<title>{{ SITE_TITLE }}</title>{% endblock %}
 {% block head_title %}Calendar: {{ object.name }}{% endblock %}
 {% block tab_id %}id='home_tab'{% endblock %}
 {% block extrahead %}

--- a/wbee/context_processors/site_title.py
+++ b/wbee/context_processors/site_title.py
@@ -1,0 +1,6 @@
+from django.conf import settings
+
+
+def site_title(request):
+    """Return site title from settings"""
+    return {"SITE_TITLE": getattr(settings, "SITE_TITLE", "WBee")}

--- a/wbee/settings/base.py
+++ b/wbee/settings/base.py
@@ -110,6 +110,7 @@ TEMPLATES = [
                 'django.template.context_processors.media',
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
+                'wbee.context_processors.site_title.site_title',
             ],
         },
     },
@@ -420,6 +421,7 @@ if DEBUG:
 
 # Company-specific configurations
 COMPANY_NAME = config('COMPANY_NAME', default='WBEE Universal Company')
+SITE_TITLE = config('SITE_TITLE', default='WBEE Universal Company Manager')
 COMPANY_ADDRESS = config('COMPANY_ADDRESS', default='')
 COMPANY_PHONE = config('COMPANY_PHONE', default='')
 COMPANY_EMAIL = config('COMPANY_EMAIL', default='info@wbee.app')


### PR DESCRIPTION
## Summary
- add `SITE_TITLE` setting and context processor
- include new context processor for templates
- use `SITE_TITLE` in base and helpdesk templates
- show universal title on main page

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `python -m py_compile wbee/context_processors/site_title.py`
- `python -m py_compile wbee/settings/base.py`

------
https://chatgpt.com/codex/tasks/task_e_68567461a6908332a88f33a1e542dd45