### PR TITLE
Remove extra icon files

### DIFF
--- a/helpdesk/templates/helpdesk/base.html
+++ b/helpdesk/templates/helpdesk/base.html
@@ -107,6 +107,13 @@
     #dropdown li.headerlink:hover ul li { padding: 5px; margin: 1px; float: none; display: block; }
     </style>
 
+    <link rel="icon" href="{% static 'home/img/favicon.ico' %}">
+    <link rel="apple-touch-icon" sizes="180x180" href="{% static 'home/img/apple-touch-icon.png' %}">
+    <link rel="icon" type="image/png" sizes="96x96" href="{% static 'home/img/favicon-96x96.png' %}">
+    <link rel="icon" type="image/png" sizes="192x192" href="{% static 'home/img/favicon-192x192.png' %}">
+    <link rel="icon" type="image/png" sizes="512x512" href="{% static 'home/img/favicon-512x512.png' %}">
+    <link rel="mask-icon" href="{% static 'home/img/favicon.svg' %}" color="#000000">
+    <link rel="manifest" href="{% static 'home/img/site.webmanifest' %}">
     {% block helpdesk_head %}{% endblock %}
 
 </head>

--- a/home/templates/home/base.html
+++ b/home/templates/home/base.html
@@ -10,6 +10,13 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <link href="{% static 'home/css/sb-admin.css' %}" rel="stylesheet">
     <link href="{% static 'home/css/base.css' %}" rel="stylesheet">
+    <link rel="icon" href="{% static 'home/img/favicon.ico' %}">
+    <link rel="apple-touch-icon" sizes="180x180" href="{% static 'home/img/apple-touch-icon.png' %}">
+    <link rel="icon" type="image/png" sizes="96x96" href="{% static 'home/img/favicon-96x96.png' %}">
+    <link rel="icon" type="image/png" sizes="192x192" href="{% static 'home/img/favicon-192x192.png' %}">
+    <link rel="icon" type="image/png" sizes="512x512" href="{% static 'home/img/favicon-512x512.png' %}">
+    <link rel="mask-icon" href="{% static 'home/img/favicon.svg' %}" color="#000000">
+    <link rel="manifest" href="{% static 'home/img/site.webmanifest' %}">
     {% block extra_css %}{% endblock %}
 </head>
 <body>


### PR DESCRIPTION
## Summary
- remove favicon asset files already deployed on the server
- keep icon and manifest links in base templates

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImproperlyConfigured: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68567e3384e48332b48a9542f30d20b1