### PR TITLE
Fix slug display in TaskList admin

### DIFF
--- a/todo/admin.py
+++ b/todo/admin.py
@@ -101,13 +101,17 @@ class TaskListAdmin(admin.ModelAdmin):
         'created_by__last_name'
     )
     
-    prepopulated_fields = {'slug': ('name',)}
+    # Slug is auto-generated and not editable, but we still display it in the
+    # admin detail view. Removing it from ``prepopulated_fields`` prevents
+    # Django from treating it as a writable field.
+
     
     readonly_fields = (
+        'slug',
         'completion_stats',
         'time_analysis',
         'task_distribution',
-        'list_statistics'
+        'list_statistics',
     )
     
     fieldsets = (


### PR DESCRIPTION
## Summary
- show slug as read-only in the TaskList admin

## Testing
- `python manage.py check --settings wbee.settings.base` *(fails: OperationalError - connection refused)*
- `python manage.py test --settings wbee.settings.base` *(fails: OperationalError - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68571659210c8332bca0b0d612765165