### PR TITLE
Add card color customization

### DIFF
--- a/static/home/scss/_card.scss
+++ b/static/home/scss/_card.scss
@@ -1,0 +1,3 @@
+.card {
+  --bs-card-color: aquamarine;
+}

--- a/static/home/scss/sb-admin.scss
+++ b/static/home/scss/sb-admin.scss
@@ -8,5 +8,6 @@
 @import "navbar/navbar_toggle.scss";
 @import "navbar/navbar_colors.scss";
 @import "cards.scss";
+@import "card.scss";
 @import "login.scss";
 @import "footer.scss";


### PR DESCRIPTION
## Summary
- add a new `_card.scss` to define custom card color
- include `_card.scss` in `sb-admin.scss`

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68571750b6488332b419c341c7835f98