### PR TITLE
Add bs-card-color styling

### DIFF
--- a/static/home/css/sb-admin.css
+++ b/static/home/css/sb-admin.css
@@ -159,6 +159,7 @@ body.fixed-nav {
    ============================================ */
 
 .card {
+  --bs-card-color: aquamarine;
   border: none;
   border-radius: var(--border-radius);
   box-shadow: var(--card-shadow);
@@ -180,6 +181,7 @@ body.fixed-nav {
 
 .card-body {
   padding: 1.5rem;
+  color: var(--bs-card-color);
 }
 
 .card-footer {
@@ -759,6 +761,7 @@ body.sidenav-toggled .content-wrapper {
   }
   
   .card {
+    --bs-card-color: aquamarine;
     background: #1e293b;
     border-color: #334155;
   }
@@ -801,6 +804,7 @@ body.sidenav-toggled .content-wrapper {
 @media (max-width: 575.98px) {
   .card-body {
     padding: 1rem;
+    color: var(--bs-card-color);
   }
   
   .btn {

--- a/static/home/scss/_card.scss
+++ b/static/home/scss/_card.scss
@@ -1,3 +1,7 @@
 .card {
   --bs-card-color: aquamarine;
 }
+
+.card-body {
+  color: var(--bs-card-color);
+}


### PR DESCRIPTION
## Summary
- set `--bs-card-color` variable in card styles
- apply card color to card bodies

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: ModuleNotFoundError: No module named 'dj_database_url')*

------
https://chatgpt.com/codex/tasks/task_e_685720ce8568833286cf7e1d534167e9