### PR TITLE
Fix duplicate title tags in templates

### DIFF
--- a/asset/templates/asset/asset_detail.html
+++ b/asset/templates/asset/asset_detail.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-<title>{{ asset.name }} - Asset Details - {{ request.user.company.company_name|default:"WBEE" }}</title>
+{{ asset.name }} - Asset Details - {{ request.user.company.company_name|default:"WBEE" }}
 {% endblock %}
 
 {% block breadcrumb %}

--- a/asset/templates/asset/asset_form.html
+++ b/asset/templates/asset/asset_form.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-<title>{% if object %}Edit {{ object.name }}{% else %}Add New Asset{% endif %} - {{ request.user.company.company_name|default:"WBEE" }}</title>
+{% if object %}Edit {{ object.name }}{% else %}Add New Asset{% endif %} - {{ request.user.company.company_name|default:"WBEE" }}
 {% endblock %}
 
 {% block breadcrumb %}

--- a/asset/templates/asset/asset_list.html
+++ b/asset/templates/asset/asset_list.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-<title>Asset List - {{ request.user.company.company_name|default:"WBEE" }}</title>
+Asset List - {{ request.user.company.company_name|default:"WBEE" }}
 {% endblock %}
 
 {% block breadcrumb %}

--- a/asset/templates/asset/assignment_detail.html
+++ b/asset/templates/asset/assignment_detail.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Assignment Detail</title>{% endblock %}
+{% block title %}Assignment Detail{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'asset:assignments:list' %}">Assignments</a></li>
 <li class="breadcrumb-item active">Detail</li>

--- a/asset/templates/asset/assignment_form.html
+++ b/asset/templates/asset/assignment_form.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 {% block title %}
-<title>{% if form.instance.pk %}Edit Assignment{% else %}New Assignment{% endif %}</title>
+{% if form.instance.pk %}Edit Assignment{% else %}New Assignment{% endif %}
 {% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'asset:assignments:list' %}">Assignments</a></li>

--- a/asset/templates/asset/assignment_list.html
+++ b/asset/templates/asset/assignment_list.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Asset Assignments</title>{% endblock %}
+{% block title %}Asset Assignments{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'asset:dashboard' %}">Assets</a></li>
 <li class="breadcrumb-item active">Assignments</li>

--- a/asset/templates/asset/category_assets.html
+++ b/asset/templates/asset/category_assets.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{{ category.name }} Assets</title>{% endblock %}
+{% block title %}{{ category.name }} Assets{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'asset:categories:list' %}">Asset Categories</a></li>
 <li class="breadcrumb-item"><a href="{% url 'asset:categories:detail' category.pk %}">{{ category.name }}</a></li>

--- a/asset/templates/asset/category_confirm_delete.html
+++ b/asset/templates/asset/category_confirm_delete.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Delete Category</title>{% endblock %}
+{% block title %}Delete Category{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'asset:categories:list' %}">Asset Categories</a></li>
 <li class="breadcrumb-item active">Delete</li>

--- a/asset/templates/asset/category_detail.html
+++ b/asset/templates/asset/category_detail.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{{ category.name }}</title>{% endblock %}
+{% block title %}{{ category.name }}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'asset:categories:list' %}">Asset Categories</a></li>
 <li class="breadcrumb-item active">{{ category.name }}</li>

--- a/asset/templates/asset/category_form.html
+++ b/asset/templates/asset/category_form.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{% if form.instance.pk %}Edit Category{% else %}Add Category{% endif %}</title>{% endblock %}
+{% block title %}{% if form.instance.pk %}Edit Category{% else %}Add Category{% endif %}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'asset:categories:list' %}">Asset Categories</a></li>
 <li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Create{% endif %}</li>

--- a/asset/templates/asset/category_list.html
+++ b/asset/templates/asset/category_list.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Asset Categories</title>{% endblock %}
+{% block title %}Asset Categories{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item active">Asset Categories</li>
 {% endblock %}

--- a/asset/templates/asset/dashboard.html
+++ b/asset/templates/asset/dashboard.html
@@ -3,7 +3,7 @@
 {% load math_filters %}
 
 {% block title %}
-<title>Asset Management Dashboard - {{ request.user.company.company_name|default:"WBEE" }}</title>
+Asset Management Dashboard - {{ request.user.company.company_name|default:"WBEE" }}
 {% endblock %}
 
 {% block breadcrumb %}

--- a/asset/templates/asset/maintenance_confirm_delete.html
+++ b/asset/templates/asset/maintenance_confirm_delete.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Delete Maintenance Record</title>{% endblock %}
+{% block title %}Delete Maintenance Record{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'asset:maintenance:list' %}">Maintenance</a></li>
 <li class="breadcrumb-item active">Delete</li>

--- a/asset/templates/asset/maintenance_detail.html
+++ b/asset/templates/asset/maintenance_detail.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Maintenance Detail</title>{% endblock %}
+{% block title %}Maintenance Detail{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'asset:maintenance:list' %}">Maintenance</a></li>
 <li class="breadcrumb-item active">Detail</li>

--- a/asset/templates/asset/maintenance_form.html
+++ b/asset/templates/asset/maintenance_form.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{% if object %}Edit{% else %}Add{% endif %} Maintenance</title>{% endblock %}
+{% block title %}{% if object %}Edit{% else %}Add{% endif %} Maintenance{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'asset:maintenance:list' %}">Maintenance</a></li>
 <li class="breadcrumb-item active">{% if object %}Edit{% else %}Add{% endif %}</li>

--- a/asset/templates/asset/maintenance_list.html
+++ b/asset/templates/asset/maintenance_list.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Maintenance Records</title>{% endblock %}
+{% block title %}Maintenance Records{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'asset:dashboard' %}">Assets</a></li>
 <li class="breadcrumb-item active">Maintenance</li>

--- a/asset/templates/asset/maintenance_overdue.html
+++ b/asset/templates/asset/maintenance_overdue.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Overdue Maintenance</title>{% endblock %}
+{% block title %}Overdue Maintenance{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'asset:maintenance:list' %}">Maintenance</a></li>
 <li class="breadcrumb-item active">Overdue</li>

--- a/asset/templates/asset/maintenance_schedule_overview.html
+++ b/asset/templates/asset/maintenance_schedule_overview.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Maintenance Schedule</title>{% endblock %}
+{% block title %}Maintenance Schedule{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'asset:maintenance:list' %}">Maintenance</a></li>
 <li class="breadcrumb-item active">Schedule</li>

--- a/asset/templates/asset/maintenance_upcoming.html
+++ b/asset/templates/asset/maintenance_upcoming.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Upcoming Maintenance</title>{% endblock %}
+{% block title %}Upcoming Maintenance{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'asset:maintenance:list' %}">Maintenance</a></li>
 <li class="breadcrumb-item active">Upcoming</li>

--- a/client/templates/client/client_confirm_delete.html
+++ b/client/templates/client/client_confirm_delete.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-<title>Delete {{ object.company_name }} - Confirm Deletion</title>
+Delete {{ object.company_name }} - Confirm Deletion
 {% endblock %}
 
 {% block breadcrumb %}

--- a/client/templates/client/client_dashboard.html
+++ b/client/templates/client/client_dashboard.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-<title>Client Management Dashboard - {{ request.user.company.company_name|default:"WBEE" }}</title>
+Client Management Dashboard - {{ request.user.company.company_name|default:"WBEE" }}
 {% endblock %}
 
 {% block breadcrumb %}

--- a/client/templates/client/client_detail.html
+++ b/client/templates/client/client_detail.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-<title>{{ client_detail.company_name }} - Client Details</title>
+{{ client_detail.company_name }} - Client Details
 {% endblock %}
 
 {% block breadcrumb %}

--- a/client/templates/client/client_effort_list.html
+++ b/client/templates/client/client_effort_list.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>{{ client.company_name }} - Efforts</title>{% endblock %}
+{% block title %}{{ client.company_name }} - Efforts{% endblock %}
 
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'client:dashboard' %}">Client Management</a></li>

--- a/client/templates/client/client_financial_dashboard.html
+++ b/client/templates/client/client_financial_dashboard.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-<title>{{ client.company_name }} - Financial Dashboard</title>
+{{ client.company_name }} - Financial Dashboard
 {% endblock %}
 
 {% block breadcrumb %}

--- a/client/templates/client/client_form.html
+++ b/client/templates/client/client_form.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-<title>{% if client %}Update {{ client.company_name }}{% else %}Create New Client{% endif %} - WBEE</title>
+{% if client %}Update {{ client.company_name }}{% else %}Create New Client{% endif %} - WBEE
 {% endblock %}
 
 {% block breadcrumb %}

--- a/client/templates/client/client_list.html
+++ b/client/templates/client/client_list.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-<title>Client Directory - {{ request.user.company.company_name|default:"WBEE" }}</title>
+Client Directory - {{ request.user.company.company_name|default:"WBEE" }}
 {% endblock %}
 
 {% block breadcrumb %}

--- a/company/templates/company/base_company.html
+++ b/company/templates/company/base_company.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>{% block page_title %}Company Management{% endblock %}</title>{% endblock %}
+{% block title %}{% block page_title %}Company Management{% endblock %}{% endblock %}
 
 {% block extra_css %}
 <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">

--- a/helpdesk/templates/helpdesk/base.html
+++ b/helpdesk/templates/helpdesk/base.html
@@ -15,7 +15,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title>{% block title %}{% block helpdesk_title %}{{ SITE_TITLE }}{% endblock %}{% endblock %} :: {% trans "Powered by django-helpdesk" %}</title>
+    {% block title %}{% block helpdesk_title %}{{ SITE_TITLE }}{% endblock %}{% endblock %} :: {% trans "Powered by django-helpdesk" %}
 
     <!-- Bootstrap Core CSS -->
     {% if helpdesk_settings.HELPDESK_USE_CDN %}

--- a/helpdesk/templates/helpdesk/help_base.html
+++ b/helpdesk/templates/helpdesk/help_base.html
@@ -36,7 +36,7 @@
             padding-left: 2em;
         }
         </style>
-        <title>{% block title %}{{ SITE_TITLE }} Help{% endblock %}</title>
+        {% block title %}{{ SITE_TITLE }} Help{% endblock %}
     </head>
     <body>
         <h1>{% block heading %}django-helpdesk Help{% endblock %}</h1>

--- a/helpdesk/templates/helpdesk/public_base.html
+++ b/helpdesk/templates/helpdesk/public_base.html
@@ -13,7 +13,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title>{% block title %}{% block helpdesk_title %}{{ SITE_TITLE }}{% endblock %}{% endblock %}</title>
+    {% block title %}{% block helpdesk_title %}{{ SITE_TITLE }}{% endblock %}{% endblock %}
 
     <!-- Bootstrap Core CSS -->
     {% if helpdesk_settings.HELPDESK_USE_CDN %}

--- a/home/templates/email.html
+++ b/home/templates/email.html
@@ -1,6 +1,6 @@
 {% extends "home/basecontact.html" %}
 
-{% block title %}<title>ContactUs</title> {% endblock %}
+{% block title %}ContactUs {% endblock %}
 
 
 {% block content %}<!-- templates/email.html -->

--- a/home/templates/home/base.html
+++ b/home/templates/home/base.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}{{ SITE_TITLE }}{% endblock %}</title>
+    {% block title %}{{ SITE_TITLE }}{% endblock %}
     
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">

--- a/home/templates/registration/login.html
+++ b/home/templates/registration/login.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="description" content="">
   <meta name="author" content="Dr. Nope">
-  {% block title %}<title>Distro TimeSaver</title>{% endblock %}
+  {% block title %}Distro TimeSaver{% endblock %}
   <!-- Bootstrap core CSS-->
   <link href="{% static 'home/vendor/bootstrap/css/bootstrap.min.css' %}" rel="stylesheet">
   <!-- Custom fonts for this template-->

--- a/hr/templates/hr/dashboard.html
+++ b/hr/templates/hr/dashboard.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>HR Dashboard</title>{% endblock %}
+{% block title %}HR Dashboard{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'hr:index' %}">HR</a></li>
 <li class="breadcrumb-item active">Dashboard</li>

--- a/hr/templates/hr/worker_confirm_delete.html
+++ b/hr/templates/hr/worker_confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>Delete {{ object.get_full_name }} - Confirm</title>{% endblock %}
+{% block title %}Delete {{ object.get_full_name }} - Confirm{% endblock %}
 
 {% block breadcrumb %}
 / <a href="{% url 'hr:index' %}">HR</a> 

--- a/hr/templates/hr/worker_detail.html
+++ b/hr/templates/hr/worker_detail.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>{{ worker.get_full_name }} - Staff Details</title>{% endblock %}
+{% block title %}{{ worker.get_full_name }} - Staff Details{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'hr:index' %}">HR</a></li>
 <li class="breadcrumb-item"><a href="{% url 'hr:worker-list' %}">Staff</a></li>

--- a/hr/templates/hr/worker_form.html
+++ b/hr/templates/hr/worker_form.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-<title>{% if object %}Edit {{ object.get_full_name }}{% else %}Add New Worker{% endif %}</title>
+{% if object %}Edit {{ object.get_full_name }}{% else %}Add New Worker{% endif %}
 {% endblock %}
 
 {% block breadcrumb %}

--- a/hr/templates/hr/worker_list.html
+++ b/hr/templates/hr/worker_list.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>Staff List</title>{% endblock %}
+{% block title %}Staff List{% endblock %}
 {% block styler %}<link href="{% static 'home/vendor/datatables/dataTables.bootstrap4.css' %}" rel="stylesheet" type="text/css"> {% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'hr:index' %}">HR</a></li>

--- a/location/templates/location/analytics.html
+++ b/location/templates/location/analytics.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>Location Analytics Dashboard</title>{% endblock %}
+{% block title %}Location Analytics Dashboard{% endblock %}
 {% block breadcrumb %}/ <a href="{% url 'location:location-list' %}">Locations</a> / Analytics{% endblock %}
 
 {% block styler %}

--- a/location/templates/location/document_detail.html
+++ b/location/templates/location/document_detail.html
@@ -661,7 +661,7 @@ function printDocument() {
                 printWindow.document.write(`
                     <html>
                         <head>
-                            <title>Print - {{ document.title }}</title>
+                            Print - {{ document.title }}
                             <style>
                                 body { margin: 0; padding: 20px; text-align: center; }
                                 img { max-width: 100%; height: auto; }

--- a/location/templates/location/location_confirm_delete.html
+++ b/location/templates/location/location_confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>Delete Location - {{ object.name }}</title>{% endblock %}
+{% block title %}Delete Location - {{ object.name }}{% endblock %}
 {% block breadcrumb %}
 / <a href="{% url 'location:location-list' %}">Locations</a>
 / <a href="{{ object.get_absolute_url }}">{{ object.name }}</a>

--- a/location/templates/location/location_dashboard.html
+++ b/location/templates/location/location_dashboard.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>Location Dashboard</title>{% endblock %}
+{% block title %}Location Dashboard{% endblock %}
 {% block breadcrumb %}
     <li class="breadcrumb-item active" aria-current="page">Location Dashboard</li>
 {% endblock %}

--- a/location/templates/location/location_detail.html
+++ b/location/templates/location/location_detail.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>{{ location.name }} - Location Details</title>{% endblock %}
+{% block title %}{{ location.name }} - Location Details{% endblock %}
 {% block breadcrumb %}
 / <a href="{% url 'location:location-list' %}">Locations</a>
 / {{ location.name }}

--- a/location/templates/location/location_import.html
+++ b/location/templates/location/location_import.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>Import Locations</title>{% endblock %}
+{% block title %}Import Locations{% endblock %}
 {% block breadcrumb %}/ <a href="{% url 'location:location-list' %}">Locations</a> / Import{% endblock %}
 
 {% block styler %}

--- a/location/templates/location/locations_map.html
+++ b/location/templates/location/locations_map.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>Locations Map</title>{% endblock %}
+{% block title %}Locations Map{% endblock %}
 {% block breadcrumb %}/ <a href="{% url 'location:location-list' %}">Locations</a> / Map View{% endblock %}
 
 {% block styler %}

--- a/location/templates/location/note_confirm_delete.html
+++ b/location/templates/location/note_confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>Delete Note - {{ object.title }}</title>{% endblock %}
+{% block title %}Delete Note - {{ object.title }}{% endblock %}
 {% block breadcrumb %}
 / <a href="{% url 'location:location-list' %}">Locations</a>
 / <a href="{{ object.location.get_absolute_url }}">{{ object.location.name }}</a>

--- a/location/templates/location/note_detail.html
+++ b/location/templates/location/note_detail.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>{{ note.title }} - Note Details</title>{% endblock %}
+{% block title %}{{ note.title }} - Note Details{% endblock %}
 {% block breadcrumb %}
 / <a href="{% url 'location:location-list' %}">Locations</a>
 / <a href="{{ note.location.get_absolute_url }}">{{ note.location.name }}</a>

--- a/location/templates/location/note_form.html
+++ b/location/templates/location/note_form.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>{% if object %}Edit Note{% else %}Add Note{% endif %} - {{ location.name }}</title>{% endblock %}
+{% block title %}{% if object %}Edit Note{% else %}Add Note{% endif %} - {{ location.name }}{% endblock %}
 {% block breadcrumb %}
 / <a href="{% url 'location:location-list' %}">Locations</a>
 / <a href="{{ location.get_absolute_url }}">{{ location.name }}</a>

--- a/location/templates/location/note_list.html
+++ b/location/templates/location/note_list.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>Notes - {{ location.name }}</title>{% endblock %}
+{% block title %}Notes - {{ location.name }}{% endblock %}
 {% block breadcrumb %}
 / <a href="{% url 'location:location-list' %}">Locations</a>
 / <a href="{{ location.get_absolute_url }}">{{ location.name }}</a>

--- a/material/templates/material/category_confirm_delete.html
+++ b/material/templates/material/category_confirm_delete.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Delete Category</title>{% endblock %}
+{% block title %}Delete Category{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:category-list' %}">Product Categories</a></li>
 <li class="breadcrumb-item active">Delete</li>

--- a/material/templates/material/category_detail.html
+++ b/material/templates/material/category_detail.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{{ category.name }}</title>{% endblock %}
+{% block title %}{{ category.name }}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:category-list' %}">Product Categories</a></li>
 <li class="breadcrumb-item active">{{ category.name }}</li>

--- a/material/templates/material/category_form.html
+++ b/material/templates/material/category_form.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{% if form.instance.pk %}Edit Category{% else %}Add Category{% endif %}</title>{% endblock %}
+{% block title %}{% if form.instance.pk %}Edit Category{% else %}Add Category{% endif %}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:category-list' %}">Product Categories</a></li>
 <li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Create{% endif %}</li>

--- a/material/templates/material/category_list.html
+++ b/material/templates/material/category_list.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Product Categories</title>{% endblock %}
+{% block title %}Product Categories{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item active">Product Categories</li>
 {% endblock %}

--- a/material/templates/material/manufacturer_confirm_delete.html
+++ b/material/templates/material/manufacturer_confirm_delete.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Delete Manufacturer</title>{% endblock %}
+{% block title %}Delete Manufacturer{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:manufacturer-list' %}">Manufacturers</a></li>
 <li class="breadcrumb-item active">Delete</li>

--- a/material/templates/material/manufacturer_detail.html
+++ b/material/templates/material/manufacturer_detail.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{{ manufacturer.name }}</title>{% endblock %}
+{% block title %}{{ manufacturer.name }}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:manufacturer-list' %}">Manufacturers</a></li>
 <li class="breadcrumb-item active">{{ manufacturer.name }}</li>

--- a/material/templates/material/manufacturer_form.html
+++ b/material/templates/material/manufacturer_form.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{% if form.instance.pk %}Edit Manufacturer{% else %}Add Manufacturer{% endif %}</title>{% endblock %}
+{% block title %}{% if form.instance.pk %}Edit Manufacturer{% else %}Add Manufacturer{% endif %}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:manufacturer-list' %}">Manufacturers</a></li>
 <li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Create{% endif %}</li>

--- a/material/templates/material/manufacturer_list.html
+++ b/material/templates/material/manufacturer_list.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Manufacturers</title>{% endblock %}
+{% block title %}Manufacturers{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item active">Manufacturers</li>
 {% endblock %}

--- a/material/templates/material/product_confirm_delete.html
+++ b/material/templates/material/product_confirm_delete.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Delete Product</title>{% endblock %}
+{% block title %}Delete Product{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:product-list' %}">Products</a></li>
 <li class="breadcrumb-item active">Delete</li>

--- a/material/templates/material/product_detail.html
+++ b/material/templates/material/product_detail.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{{ product.name }}</title>{% endblock %}
+{% block title %}{{ product.name }}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:product-list' %}">Products</a></li>
 <li class="breadcrumb-item active">{{ product.name }}</li>

--- a/material/templates/material/product_form.html
+++ b/material/templates/material/product_form.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{% if form.instance.pk %}Edit Product{% else %}Add Product{% endif %}</title>{% endblock %}
+{% block title %}{% if form.instance.pk %}Edit Product{% else %}Add Product{% endif %}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:product-list' %}">Products</a></li>
 <li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Create{% endif %}</li>

--- a/material/templates/material/product_list.html
+++ b/material/templates/material/product_list.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Products</title>{% endblock %}
+{% block title %}Products{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item active">Products</li>
 {% endblock %}

--- a/material/templates/material/supplier_confirm_delete.html
+++ b/material/templates/material/supplier_confirm_delete.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Delete Supplier</title>{% endblock %}
+{% block title %}Delete Supplier{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:supplier-list' %}">Suppliers</a></li>
 <li class="breadcrumb-item active">Delete</li>

--- a/material/templates/material/supplier_detail.html
+++ b/material/templates/material/supplier_detail.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{{ supplier.company_name }}</title>{% endblock %}
+{% block title %}{{ supplier.company_name }}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:supplier-list' %}">Suppliers</a></li>
 <li class="breadcrumb-item active">{{ supplier.company_name }}</li>

--- a/material/templates/material/supplier_form.html
+++ b/material/templates/material/supplier_form.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{% if form.instance.pk %}Edit Supplier{% else %}Add Supplier{% endif %}</title>{% endblock %}
+{% block title %}{% if form.instance.pk %}Edit Supplier{% else %}Add Supplier{% endif %}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:supplier-list' %}">Suppliers</a></li>
 <li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Create{% endif %}</li>

--- a/material/templates/material/supplier_list.html
+++ b/material/templates/material/supplier_list.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Suppliers</title>{% endblock %}
+{% block title %}Suppliers{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item active">Suppliers</li>
 {% endblock %}

--- a/material/templates/material/transaction_confirm_delete.html
+++ b/material/templates/material/transaction_confirm_delete.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Delete Transaction</title>{% endblock %}
+{% block title %}Delete Transaction{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:transaction-list' %}">Inventory Transactions</a></li>
 <li class="breadcrumb-item active">Delete</li>

--- a/material/templates/material/transaction_detail.html
+++ b/material/templates/material/transaction_detail.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Transaction</title>{% endblock %}
+{% block title %}Transaction{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:transaction-list' %}">Inventory Transactions</a></li>
 <li class="breadcrumb-item active">Detail</li>

--- a/material/templates/material/transaction_form.html
+++ b/material/templates/material/transaction_form.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{% if form.instance.pk %}Edit Transaction{% else %}Add Transaction{% endif %}</title>{% endblock %}
+{% block title %}{% if form.instance.pk %}Edit Transaction{% else %}Add Transaction{% endif %}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'material:transaction-list' %}">Inventory Transactions</a></li>
 <li class="breadcrumb-item active">{% if form.instance.pk %}Edit{% else %}Create{% endif %}</li>

--- a/material/templates/material/transaction_list.html
+++ b/material/templates/material/transaction_list.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Inventory Transactions</title>{% endblock %}
+{% block title %}Inventory Transactions{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item active">Inventory Transactions</li>
 {% endblock %}

--- a/project/templates/project/active_projects.html
+++ b/project/templates/project/active_projects.html
@@ -1,7 +1,7 @@
 {% extends "project/base.html" %}
 {% load static %}
 
-{% block title %}<title>Active Projects</title>{% endblock %}
+{% block title %}Active Projects{% endblock %}
 
 {% block extra_css %}
 <link href="{% static 'home/vendor/datatables/dataTables.bootstrap4.css' %}" rel="stylesheet">

--- a/project/templates/project/calendar.html
+++ b/project/templates/project/calendar.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/change_form.html
+++ b/project/templates/project/change_form.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/change_list.html
+++ b/project/templates/project/change_list.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/complete_projects.html
+++ b/project/templates/project/complete_projects.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/dashboard.html
+++ b/project/templates/project/dashboard.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Project Dashboard</title>{% endblock %}
+{% block title %}Project Dashboard{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item active">Projects</li>
 {% endblock %}

--- a/project/templates/project/device_confirm_delete.html
+++ b/project/templates/project/device_confirm_delete.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Delete {{ material_type }}</title>{% endblock %}
+{% block title %}Delete {{ material_type }}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:project-detail' object.project.job_number %}">{{ object.project.job_number }}</a></li>
 <li class="breadcrumb-item"><a href="{% url list_url_name object.project.job_number %}">{{ material_type }}s</a></li>

--- a/project/templates/project/device_detail.html
+++ b/project/templates/project/device_detail.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 {% load humanize %}
-{% block title %}<title>{{ material_type }} Detail</title>{% endblock %}
+{% block title %}{{ material_type }} Detail{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:project-detail' object.project.job_number %}">{{ object.project.job_number }}</a></li>
 <li class="breadcrumb-item"><a href="{% url list_url_name object.project.job_number %}">{{ material_type }}s</a></li>

--- a/project/templates/project/device_form.html
+++ b/project/templates/project/device_form.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{% if form.instance.pk %}Edit {{ material_type }}{% else %}Add {{ material_type }}{% endif %}</title>{% endblock %}
+{% block title %}{% if form.instance.pk %}Edit {{ material_type }}{% else %}Add {{ material_type }}{% endif %}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:project-detail' project.job_number %}">{{ project.job_number }}</a></li>
 <li class="breadcrumb-item"><a href="{% url list_url_name project.job_number %}">{{ material_type }}s</a></li>

--- a/project/templates/project/device_list.html
+++ b/project/templates/project/device_list.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 {% load humanize %}
-{% block title %}<title>{{ material_type }}s - {{ project.name }}</title>{% endblock %}
+{% block title %}{{ material_type }}s - {{ project.name }}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:project-detail' project.job_number %}">{{ project.job_number }}</a></li>
 <li class="breadcrumb-item active">{{ material_type }}s</li>

--- a/project/templates/project/milestone_form.html
+++ b/project/templates/project/milestone_form.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/milestone_list.html
+++ b/project/templates/project/milestone_list.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/my_assignments.html
+++ b/project/templates/project/my_assignments.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/overdue_projects.html
+++ b/project/templates/project/overdue_projects.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/placeholder.html
+++ b/project/templates/project/placeholder.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/project_activity.html
+++ b/project/templates/project/project_activity.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{{ project.name }} Activity</title>{% endblock %}
+{% block title %}{{ project.name }} Activity{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:dashboard' %}">Projects</a></li>
 <li class="breadcrumb-item"><a href="{% url 'project:project-detail' project.job_number %}">{{ project.name }}</a></li>

--- a/project/templates/project/project_confirm_delete.html
+++ b/project/templates/project/project_confirm_delete.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Delete {{ project.name }}</title>{% endblock %}
+{% block title %}Delete {{ project.name }}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:dashboard' %}">Projects</a></li>
 <li class="breadcrumb-item"><a href="{% url 'project:project-list' %}">List</a></li>

--- a/project/templates/project/project_detail.html
+++ b/project/templates/project/project_detail.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{{ project.name }}</title>{% endblock %}
+{% block title %}{{ project.name }}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:dashboard' %}">Projects</a></li>
 <li class="breadcrumb-item"><a href="{% url 'project:project-list' %}">List</a></li>

--- a/project/templates/project/project_detail_full.html
+++ b/project/templates/project/project_detail_full.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>Project details</title>{% endblock %}
+{% block title %}Project details{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'location:location-list' %}">Job Site</a></li>
 <li class="breadcrumb-item"><a href="{% url 'project:project-list' %}">Project</a></li>

--- a/project/templates/project/project_financial.html
+++ b/project/templates/project/project_financial.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/project_form.html
+++ b/project/templates/project/project_form.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>{% if form.instance.pk %}Edit Project{% else %}New Project{% endif %}</title>{% endblock %}
+{% block title %}{% if form.instance.pk %}Edit Project{% else %}New Project{% endif %}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:dashboard' %}">Projects</a></li>
 <li class="breadcrumb-item"><a href="{% url 'project:project-list' %}">List</a></li>

--- a/project/templates/project/project_list.html
+++ b/project/templates/project/project_list.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Projects</title>{% endblock %}
+{% block title %}Projects{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:dashboard' %}">Projects</a></li>
 <li class="breadcrumb-item active">List</li>

--- a/project/templates/project/project_materials.html
+++ b/project/templates/project/project_materials.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/project_progress.html
+++ b/project/templates/project/project_progress.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/project_status_form.html
+++ b/project/templates/project/project_status_form.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Update Status - {{ project.name }}</title>{% endblock %}
+{% block title %}Update Status - {{ project.name }}{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:dashboard' %}">Projects</a></li>
 <li class="breadcrumb-item"><a href="{% url 'project:project-detail' project.job_number %}">{{ project.name }}</a></li>

--- a/project/templates/project/project_team.html
+++ b/project/templates/project/project_team.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/project_timeline.html
+++ b/project/templates/project/project_timeline.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/quick_actions.html
+++ b/project/templates/project/quick_actions.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/recently_viewed.html
+++ b/project/templates/project/recently_viewed.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/reports.html
+++ b/project/templates/project/reports.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/reports/financial_report.html
+++ b/project/templates/project/reports/financial_report.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/reports/progress_report.html
+++ b/project/templates/project/reports/progress_report.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/reports/team_performance.html
+++ b/project/templates/project/reports/team_performance.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/reports/utilization_report.html
+++ b/project/templates/project/reports/utilization_report.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/scope_confirm_delete.html
+++ b/project/templates/project/scope_confirm_delete.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/scope_detail.html
+++ b/project/templates/project/scope_detail.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/scope_form.html
+++ b/project/templates/project/scope_form.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/scope_list.html
+++ b/project/templates/project/scope_list.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/settings.html
+++ b/project/templates/project/settings.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/project/templates/project/system_status.html
+++ b/project/templates/project/system_status.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% block title %}<title>Feature Unavailable</title>{% endblock %}
+{% block title %}Feature Unavailable{% endblock %}
 {% block content %}
 <div class="alert alert-warning mt-4">
   This feature is not yet implemented.

--- a/receipts/templates/receipts/purchase_type_confirm_delete.html
+++ b/receipts/templates/receipts/purchase_type_confirm_delete.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>Delete Purchase Type</title>{% endblock %}
+{% block title %}Delete Purchase Type{% endblock %}
 
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'receipts:purchase-type-list' %}">Purchase Types</a></li>

--- a/receipts/templates/receipts/purchase_type_detail.html
+++ b/receipts/templates/receipts/purchase_type_detail.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>{{ purchase_type.name }}</title>{% endblock %}
+{% block title %}{{ purchase_type.name }}{% endblock %}
 
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'receipts:purchase-type-list' %}">Purchase Types</a></li>

--- a/receipts/templates/receipts/purchase_type_form.html
+++ b/receipts/templates/receipts/purchase_type_form.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 
 {% block title %}
-<title>{% if form.instance.pk %}Edit Purchase Type{% else %}New Purchase Type{% endif %}</title>
+{% if form.instance.pk %}Edit Purchase Type{% else %}New Purchase Type{% endif %}
 {% endblock %}
 
 {% block breadcrumb %}

--- a/receipts/templates/receipts/purchase_type_list.html
+++ b/receipts/templates/receipts/purchase_type_list.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>Purchase Types</title>{% endblock %}
+{% block title %}Purchase Types{% endblock %}
 
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'receipts:list' %}">Receipts</a></li>

--- a/receipts/templates/receipts/receipt_confirm_delete.html
+++ b/receipts/templates/receipts/receipt_confirm_delete.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>Delete Receipt</title>{% endblock %}
+{% block title %}Delete Receipt{% endblock %}
 
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'receipts:list' %}">Receipts</a></li>

--- a/receipts/templates/receipts/receipt_detail.html
+++ b/receipts/templates/receipts/receipt_detail.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>Receipt {{ receipt.id }}</title>{% endblock %}
+{% block title %}Receipt {{ receipt.id }}{% endblock %}
 
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'receipts:list' %}">Receipts</a></li>

--- a/receipts/templates/receipts/receipt_form.html
+++ b/receipts/templates/receipts/receipt_form.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 
 {% block title %}
-<title>{% if form.instance.pk %}Edit Receipt{% else %}New Receipt{% endif %}</title>
+{% if form.instance.pk %}Edit Receipt{% else %}New Receipt{% endif %}
 {% endblock %}
 
 {% block breadcrumb %}

--- a/receipts/templates/receipts/receipt_list.html
+++ b/receipts/templates/receipts/receipt_list.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>Receipts</title>{% endblock %}
+{% block title %}Receipts{% endblock %}
 
 {% block breadcrumb %}
 <li class="breadcrumb-item active">Receipts</li>

--- a/schedule/templates/fullcalendar.html
+++ b/schedule/templates/fullcalendar.html
@@ -1,7 +1,7 @@
 {% extends 'home/base.html' %}
 {% load i18n %}
 
-{% block title %}<title>{{ SITE_TITLE }}</title>{% endblock %}
+{% block title %}{{ SITE_TITLE }}{% endblock %}
 {% block head_title %}Calendar: {{ object.name }}{% endblock %}
 {% block tab_id %}id='home_tab'{% endblock %}
 {% block extrahead %}

--- a/schedule/templates/profiles/schedule.html
+++ b/schedule/templates/profiles/schedule.html
@@ -1,7 +1,7 @@
 
 {% extends "home/base.html" %}
 {% load i18n %}
-{% block title %}<title>The Calendar</title>{% endblock %}
+{% block title %}The Calendar{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'jobsite' %}">Jobsite</a></li>
 <li class="breadcrumb-item active">detail / {{ jobsite.job_title }}</li>

--- a/schedule/templates/schedule/calendar_day.html
+++ b/schedule/templates/schedule/calendar_day.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load scheduletags i18n %}
 
-{% block title %}<title>Calendar Day</title>{% endblock %}
+{% block title %}Calendar Day{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item active">{{ calendar.name }}</li>
 {% endblock %}

--- a/schedule/templates/schedule/calendar_month.html
+++ b/schedule/templates/schedule/calendar_month.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load scheduletags i18n %}
 
-{% block title %}<title>Calendar Month</title>{% endblock %}
+{% block title %}Calendar Month{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'calendar_list' %}">{{ calendar.name }}</a></li>
 {% endblock %}

--- a/schedule/templates/schedule/calendar_week.html
+++ b/schedule/templates/schedule/calendar_week.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load scheduletags i18n %}
 
-{% block title %}<title>Calendar Week</title>{% endblock %}
+{% block title %}Calendar Week{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item active">{{ calendar.name }}</li>
 {% endblock %}

--- a/schedule/templates/schedule/create_event.html
+++ b/schedule/templates/schedule/create_event.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 
-{% block title %}<title>Event Update</title> {% endblock %}
+{% block title %}Event Update {% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>
 <li class="breadcrumb-item active">Update Event info</li>

--- a/schedule/templates/schedule/dayevent_detail.html
+++ b/schedule/templates/schedule/dayevent_detail.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>Day event details</title>{% endblock %}
+{% block title %}Day event details{% endblock %}
 
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>

--- a/schedule/templates/schedule/delete_event.html
+++ b/schedule/templates/schedule/delete_event.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 {% load i18n %}
-{% block title %}<title>Project info Delete</title> {% endblock %}
+{% block title %}Project info Delete {% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'location:location-list' %}">Job Site</a></li>
 <li class="breadcrumb-item"><a href="{% url 'project:project-list' %}">Project</a></li>

--- a/schedule/templates/schedule/edit_occurrence.html
+++ b/schedule/templates/schedule/edit_occurrence.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load i18n %}
 
-{% block title %}<title>Event Update</title> {% endblock %}
+{% block title %}Event Update {% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>
 <li class="breadcrumb-item active">Update Event info</li>

--- a/schedule/templates/schedule/event.html
+++ b/schedule/templates/schedule/event.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load i18n scheduletags %}
 
-{% block title %}<title>Day event details</title>{% endblock %}
+{% block title %}Day event details{% endblock %}
 
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>

--- a/schedule/templates/schedule/event_archive_day.html
+++ b/schedule/templates/schedule/event_archive_day.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load i18n scheduletags %}
 {% load static %}
-{% block title %}<title>Schedule</title>{% endblock %}
+{% block title %}Schedule{% endblock %}
 {% block styler %}<link href="{% static 'home/vendor/datatables/dataTables.bootstrap4.css' %}" rel="stylesheet" type="text/css"> {% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>

--- a/schedule/templates/schedule/event_form.html
+++ b/schedule/templates/schedule/event_form.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 
-{% block title %}<title>Event Update</title> {% endblock %}
+{% block title %}Event Update {% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>
 <li class="breadcrumb-item active">Update Event info</li>

--- a/schedule/templates/schedule/schedule_day_list.html
+++ b/schedule/templates/schedule/schedule_day_list.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 {% load static %}
-{% block title %}<title>Schedule</title>{% endblock %}
+{% block title %}Schedule{% endblock %}
 {% block styler %}<link href="{% static 'home/vendor/datatables/dataTables.bootstrap4.css' %}" rel="stylesheet" type="text/css"> {% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>

--- a/timecard/templates/scheduling_timecard.html
+++ b/timecard/templates/scheduling_timecard.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>Time card</title>{% endblock %}
+{% block title %}Time card{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>
 <li class="breadcrumb-item active">Time card / TODAY IS {{ tadai }}</li>

--- a/timecard/templates/timecard.html
+++ b/timecard/templates/timecard.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>Time card</title>{% endblock %}
+{% block title %}Time card{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'timecard' %}">Time card</a></li>
 <li class="breadcrumb-item active">TODAY IS {{ tadai }}</li>

--- a/timecard/templates/timecard/timecard_archive_week.html
+++ b/timecard/templates/timecard/timecard_archive_week.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>Time card</title>{% endblock %}
+{% block title %}Time card{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'timecard' %}">Time card</a></li>
 {% if request.user.staff %}

--- a/timecard/templates/timecard/timecard_confirm_delete.html
+++ b/timecard/templates/timecard/timecard_confirm_delete.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>Delete time card</title>{% endblock %}
+{% block title %}Delete time card{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'timecard' %}">Time card</a></li>
 <li class="breadcrumb-item active">Time card / TODAY IS {{ tadai }}</li>

--- a/timecard/templates/timecard/timecard_form.html
+++ b/timecard/templates/timecard/timecard_form.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>Create Time Card</title>{% endblock %}
+{% block title %}Create Time Card{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'timecard' %}">Time card</a></li>
 {% endblock %}

--- a/timecard/templates/timecard/timecard_form2.html
+++ b/timecard/templates/timecard/timecard_form2.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>Create Time Card</title>{% endblock %}
+{% block title %}Create Time Card{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'timecard' %}">Time card</a></li>
 {% endblock %}

--- a/timecard/templates/timecard/timecard_formup.html
+++ b/timecard/templates/timecard/timecard_formup.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>Create Time Card</title>{% endblock %}
+{% block title %}Create Time Card{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'timecard' %}">Time card</a></li>
 {% endblock %}

--- a/timecard/templates/timecard/timecard_list.html
+++ b/timecard/templates/timecard/timecard_list.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>My Timecards</title>{% endblock %}
+{% block title %}My Timecards{% endblock %}
 
 {% block extra_css %}
 <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">

--- a/timecard/templates/timecard/timecard_update_form.html
+++ b/timecard/templates/timecard/timecard_update_form.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 
-{% block title %}<title>Time card</title>{% endblock %}
+{% block title %}Time card{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'timecard' %}">Time card</a></li>
 {% if request.user.staff %}

--- a/todo/templates/todo/add_list.html
+++ b/todo/templates/todo/add_list.html
@@ -1,6 +1,6 @@
 {% extends "todo/base.html" %}
 {% block page_heading %}{% endblock %}
-{% block title %}<title>Add Todo List</title>{% endblock %}
+{% block title %}Add Todo List{% endblock %}
 
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'location:location-list' %}">Job Site</a></li>

--- a/todo/templates/todo/add_task_external.html
+++ b/todo/templates/todo/add_task_external.html
@@ -1,6 +1,6 @@
 {% extends "todo/base.html" %}
 {% block page_heading %}{% endblock %}
-{% block title %}<title>File Ticket</title>{% endblock %}
+{% block title %}File Ticket{% endblock %}
 
 {% block content %}
 

--- a/todo/templates/todo/del_list.html
+++ b/todo/templates/todo/del_list.html
@@ -1,5 +1,5 @@
 {% extends "todo/base.html" %}
-{% block title %}<title>Delete list</title>{% endblock %}
+{% block title %}Delete list{% endblock %}
 
 {% block content %}
   {% if user.is_staff %}

--- a/todo/templates/todo/list_detail.html
+++ b/todo/templates/todo/list_detail.html
@@ -1,7 +1,7 @@
 {% extends "todo/base.html" %}
 {% load static %}
 
-{% block title %}<title>Todo List: {{ task_list.name }}</title>
+{% block title %}Todo List: {{ task_list.name }}
 {% endblock %}
 
 {% block breadcrumb %}

--- a/todo/templates/todo/list_lists.html
+++ b/todo/templates/todo/list_lists.html
@@ -1,6 +1,6 @@
 {% extends "todo/base.html" %}
 
-{% block title %}<title>{{ list_title }} Todo Lists</title>{% endblock %}
+{% block title %}{{ list_title }} Todo Lists{% endblock %}
 
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'location:location-list' %}">Job Site</a></li>

--- a/todo/templates/todo/search_results.html
+++ b/todo/templates/todo/search_results.html
@@ -1,6 +1,6 @@
 {% extends "todo/base.html" %}
 
-{% block title %}<title>Search results</title>{% endblock %}
+{% block title %}Search results{% endblock %}
 {% block content_title %}<h2 class="page_title">Search</h2>{% endblock %}
 
 {% block content %}

--- a/todo/templates/todo/task_detail.html
+++ b/todo/templates/todo/task_detail.html
@@ -1,6 +1,6 @@
 {% extends "todo/base.html" %}
 
-{% block title %}<title>Task:{{ task.title }}</title>{% endblock %}
+{% block title %}Task:{{ task.title }}{% endblock %}
 
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'location:location-list' %}">Job Site</a></li>

--- a/wip/templates/wip/wipitem_list.html
+++ b/wip/templates/wip/wipitem_list.html
@@ -1,7 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 
-{% block title %}<title>Work In Progress</title>{% endblock %}
+{% block title %}Work In Progress{% endblock %}
 
 {% block breadcrumb %}
 <li class="breadcrumb-item active">WIP</li>


### PR DESCRIPTION
## Summary
- remove nested `<title>` tags from template `title` blocks

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6857ca34ce1c83328f67a4dba17700c1