### PR TITLE
Fix page titles based on breadcrumbs

### DIFF
--- a/helpdesk/templates/helpdesk/base.html
+++ b/helpdesk/templates/helpdesk/base.html
@@ -15,7 +15,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    {% block title %}{% block helpdesk_title %}{{ SITE_TITLE }}{% endblock %}{% endblock %} :: {% trans "Powered by django-helpdesk" %}
+    <title>{% block title %}{% block helpdesk_title %}{{ SITE_TITLE }}{% endblock %}{% endblock %} :: {% trans "Powered by django-helpdesk" %}</title>
 
     <!-- Bootstrap Core CSS -->
     {% if helpdesk_settings.HELPDESK_USE_CDN %}

--- a/helpdesk/templates/helpdesk/help_base.html
+++ b/helpdesk/templates/helpdesk/help_base.html
@@ -36,7 +36,7 @@
             padding-left: 2em;
         }
         </style>
-        {% block title %}{{ SITE_TITLE }} Help{% endblock %}
+        <title>{% block title %}{{ SITE_TITLE }} Help{% endblock %}</title>
     </head>
     <body>
         <h1>{% block heading %}django-helpdesk Help{% endblock %}</h1>

--- a/helpdesk/templates/helpdesk/public_base.html
+++ b/helpdesk/templates/helpdesk/public_base.html
@@ -13,7 +13,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    {% block title %}{% block helpdesk_title %}{{ SITE_TITLE }}{% endblock %}{% endblock %}
+    <title>{% block title %}{% block helpdesk_title %}{{ SITE_TITLE }}{% endblock %}{% endblock %}</title>
 
     <!-- Bootstrap Core CSS -->
     {% if helpdesk_settings.HELPDESK_USE_CDN %}

--- a/home/templates/home/base.html
+++ b/home/templates/home/base.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    {% block title %}{{ SITE_TITLE }}{% endblock %}
+    <title>{% block title %}{{ SITE_TITLE }}{% endblock %}</title>
     
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">

--- a/home/templates/registration/logged_out.html
+++ b/home/templates/registration/logged_out.html
@@ -1,5 +1,7 @@
 {% extends "home/base.html" %}
 
+{% block title %}Logged Out{% endblock %}
+
 {% block content %}
 <p>Logged out!</p>  
 

--- a/home/templates/registration/login.html
+++ b/home/templates/registration/login.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="description" content="">
   <meta name="author" content="Dr. Nope">
-  {% block title %}Distro TimeSaver{% endblock %}
+  <title>{% block title %}Distro TimeSaver{% endblock %}</title>
   <!-- Bootstrap core CSS-->
   <link href="{% static 'home/vendor/bootstrap/css/bootstrap.min.css' %}" rel="stylesheet">
   <!-- Custom fonts for this template-->

--- a/schedule/templates/schedule/calendar.html
+++ b/schedule/templates/schedule/calendar.html
@@ -1,6 +1,8 @@
 {% extends "home/base.html" %}
 {% load i18n %}
 
+{% block title %}{% trans "Calendar metadata" %}{% endblock %}
+
 
 {% block content %}
 

--- a/schedule/templates/schedule/calendar_compact_month.html
+++ b/schedule/templates/schedule/calendar_compact_month.html
@@ -1,5 +1,7 @@
 {% extends "home/base.html" %}
 {% load scheduletags %}
+
+{% block title %}{{ calendar.name }}{% endblock %}
 {% block content %}
 <h1>{{ calendar.name }}</h1>
 {% month_table calendar period "small" %}

--- a/schedule/templates/schedule/calendar_list.html
+++ b/schedule/templates/schedule/calendar_list.html
@@ -1,6 +1,6 @@
 {% extends "home/base.html" %}
 {% load i18n %}
-{% block head_title %}{% trans "Available Calendars" %}{% endblock %}
+{% block title %}{% trans "Available Calendars" %}{% endblock %}
 {% block content %}
 <h2>{% trans "Available Calendars" %}</h2>
 <ul>

--- a/schedule/templates/schedule/calendar_tri_month.html
+++ b/schedule/templates/schedule/calendar_tri_month.html
@@ -1,6 +1,8 @@
 {% extends "home/base.html" %}
 {% load scheduletags i18n %}
 
+{% block title %}{{ calendar.name }}{% endblock %}
+
 {% block breadcrumb %}
 <li class="breadcrumb-item active">{{ calendar.name }}</li>
 {% endblock %}

--- a/schedule/templates/schedule/calendar_year.html
+++ b/schedule/templates/schedule/calendar_year.html
@@ -1,6 +1,8 @@
 {% extends "home/base.html" %}
 {% load static %}
 {% load scheduletags i18n %}
+
+{% block title %}{{ calendar.name }} - Year{% endblock %}
 {% block content %}
 
 <div class="tablewrapper">

--- a/schedule/templates/schedule/cancel_occurrence.html
+++ b/schedule/templates/schedule/cancel_occurrence.html
@@ -1,6 +1,8 @@
 {% extends "home/base.html" %}
 {% load i18n %}
 
+{% block title %}{% trans "Delete Occurrence" %}{% endblock %}
+
 {% block content %}
 <h1>{% trans "Delete" %}</h1>
 {% trans "Are you sure that you really want to cancel this occurrence?" %}

--- a/schedule/templates/schedule/occurrence.html
+++ b/schedule/templates/schedule/occurrence.html
@@ -1,6 +1,8 @@
 {% extends "home/base.html" %}
 {% load i18n scheduletags %}
 
+{% block title %}{{ occurrence.title }}{% endblock %}
+
 {% block body %}
 <div class="navigation">
   <a class="btn btn-primary gradient" href="{% url "day_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 3 %}">

--- a/todo/templates/todo/base.html
+++ b/todo/templates/todo/base.html
@@ -1,6 +1,8 @@
 {% extends "home/base.html" %}
 {% load static %}
 
+{% block title %}{{ SITE_TITLE }}{% endblock %}
+
 {% block extrahead %}
 	<!-- CSS and JavaScripts for django-todo -->
 	<link rel="stylesheet" type="text/css" href="{% static 'todo/css/styles.css' %}" />


### PR DESCRIPTION
## Summary
- add explicit titles to templates missing them so browser title bar matches page header

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6857ce1911b48332871975bc7bb372d4