### PR TITLE
Fix asset url links

### DIFF
--- a/asset/models.py
+++ b/asset/models.py
@@ -304,7 +304,8 @@ class Asset(UUIDModel, TimeStampedModel):
         return f"{self.asset_number} - {self.name}"
 
     def get_absolute_url(self):
-        return reverse("asset-detail", args=[str(self.id)])
+        """Return the canonical URL for this asset using the namespaced detail view."""
+        return reverse("asset:detail", args=[str(self.id)])
 
     # Dynamic choice methods
     def get_available_statuses(self):

--- a/asset/templates/asset/analytics.html
+++ b/asset/templates/asset/analytics.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Analytics{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Analytics</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/asset_assign.html
+++ b/asset/templates/asset/asset_assign.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Asset Assign{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Asset Assign</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/asset_bulk_assign.html
+++ b/asset/templates/asset/asset_bulk_assign.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Asset Bulk Assign{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Asset Bulk Assign</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/asset_bulk_update.html
+++ b/asset/templates/asset/asset_bulk_update.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Asset Bulk Update{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Asset Bulk Update</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/asset_checkout.html
+++ b/asset/templates/asset/asset_checkout.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Asset Checkout{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Asset Checkout</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/asset_confirm_delete.html
+++ b/asset/templates/asset/asset_confirm_delete.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Asset Confirm Delete{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Asset Confirm Delete</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/asset_detail.html
+++ b/asset/templates/asset/asset_detail.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'asset' %}">Assets</a></li>
+<li class="breadcrumb-item"><a href="{% url 'asset:list' %}">Assets</a></li>
 <li class="breadcrumb-item active">{{ asset.asset_number }}</li>
 {% endblock %}
 
@@ -77,7 +77,7 @@
                 </p>
             </div>
             <div class="col-md-4 text-end">
-                <a href="{% url 'asset' %}" class="btn btn-warning action-btn">
+                <a href="{% url 'asset:maintenance-schedule' asset.id %}" class="btn btn-warning action-btn">
                     <i class="fas fa-wrench me-2"></i>Schedule Maintenance
                 </a>
             </div>
@@ -94,28 +94,28 @@
                         <i class="fas fa-bolt me-2"></i>Quick Actions
                     </h6>
                     <div class="d-flex flex-wrap gap-2">
-                        <a href="{% url 'asset' %}" class="btn btn-primary action-btn">
+                        <a href="{% url 'asset:update' asset.id %}" class="btn btn-primary action-btn">
                             <i class="fas fa-edit me-1"></i>Edit Asset
                         </a>
                         {% if asset.status == 'available' %}
-                        <a href="{% url 'asset' %}" class="btn btn-success action-btn">
+                        <a href="{% url 'asset:assign' asset.id %}" class="btn btn-success action-btn">
                             <i class="fas fa-user-plus me-1"></i>Assign
                         </a>
                         {% elif asset.assigned_worker %}
-                        <a href="{% url 'asset' %}" class="btn btn-outline-warning action-btn">
+                        <a href="{% url 'asset:unassign' asset.id %}" class="btn btn-outline-warning action-btn">
                             <i class="fas fa-user-minus me-1"></i>Unassign
                         </a>
                         {% endif %}
-                        <a href="{% url 'asset' %}" class="btn btn-warning action-btn">
+                        <a href="{% url 'asset:maintenance' asset.id %}" class="btn btn-warning action-btn">
                             <i class="fas fa-wrench me-1"></i>Maintenance
                         </a>
-                        <a href="{% url 'asset' %}" class="btn btn-info action-btn">
+                        <a href="{% url 'asset:duplicate' asset.id %}" class="btn btn-info action-btn">
                             <i class="fas fa-copy me-1"></i>Duplicate
                         </a>
                         <button class="btn btn-secondary action-btn" onclick="window.print()">
                             <i class="fas fa-print me-1"></i>Print QR
                         </button>
-                        <a href="{% url 'asset' %}" class="btn btn-outline-danger action-btn">
+                        <a href="{% url 'asset:delete' asset.id %}" class="btn btn-outline-danger action-btn">
                             <i class="fas fa-trash me-1"></i>Delete
                         </a>
                     </div>
@@ -267,7 +267,7 @@
                             <div class="text-center text-muted py-4">
                                 <i class="fas fa-user-slash mb-3" style="font-size: 3rem;"></i>
                                 <p class="mb-0">Not currently assigned</p>
-                                <a href="{% url 'asset' %}" class="btn btn-sm btn-success mt-2">
+                                <a href="{% url 'asset:assign' asset.id %}" class="btn btn-sm btn-success mt-2">
                                     <i class="fas fa-user-plus me-1"></i>Assign Now
                                 </a>
                             </div>
@@ -410,7 +410,7 @@
                     <h6 class="mb-0">
                         <i class="fas fa-wrench me-2"></i>Maintenance History
                     </h6>
-                    <a href="{% url 'asset' %}" class="btn btn-sm btn-outline-dark">
+                    <a href="{% url 'asset:maintenance:list' %}" class="btn btn-sm btn-outline-dark">
                         View All
                     </a>
                 </div>
@@ -433,7 +433,7 @@
                     <div class="text-center text-muted py-4">
                         <i class="fas fa-wrench mb-3" style="font-size: 3rem;"></i>
                         <p class="mb-0">No maintenance records</p>
-                        <a href="{% url 'asset' %}" class="btn btn-sm btn-warning mt-2">
+                        <a href="{% url 'asset:maintenance' asset.id %}" class="btn btn-sm btn-warning mt-2">
                             <i class="fas fa-plus me-1"></i>Add Maintenance
                         </a>
                     </div>
@@ -449,7 +449,7 @@
                     <h6 class="mb-0">
                         <i class="fas fa-user-check me-2"></i>Assignment History
                     </h6>
-                    <a href="{% url 'asset' %}" class="btn btn-sm btn-outline-light">
+                    <a href="{% url 'asset:assignments:list' %}" class="btn btn-sm btn-outline-light">
                         View All
                     </a>
                 </div>
@@ -488,7 +488,7 @@
                     <div class="text-center text-muted py-4">
                         <i class="fas fa-user-slash mb-3" style="font-size: 3rem;"></i>
                         <p class="mb-0">No assignment history</p>
-                        <a href="{% url 'asset' %}" class="btn btn-sm btn-success mt-2">
+                        <a href="{% url 'asset:assign' asset.id %}" class="btn btn-sm btn-success mt-2">
                             <i class="fas fa-user-plus me-1"></i>Create Assignment
                         </a>
                     </div>

--- a/asset/templates/asset/asset_duplicate.html
+++ b/asset/templates/asset/asset_duplicate.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Asset Duplicate{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Asset Duplicate</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/asset_form.html
+++ b/asset/templates/asset/asset_form.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'asset' %}">Assets</a></li>
+<li class="breadcrumb-item"><a href="{% url 'asset:list' %}">Assets</a></li>
 {% if object %}
 <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{{ object.asset_number }}</a></li>
 <li class="breadcrumb-item active">Edit</li>

--- a/asset/templates/asset/asset_import.html
+++ b/asset/templates/asset/asset_import.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Asset Import{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Asset Import</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/asset_list2.html
+++ b/asset/templates/asset/asset_list2.html
@@ -44,7 +44,7 @@
                         </ul>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="{% url 'asset:maintenance-list' %}">
+                        <a class="nav-link" href="{% url 'asset:maintenance:list' %}">
                             <i class="fas fa-wrench me-1"></i>Maintenance
                         </a>
                     </li>

--- a/asset/templates/asset/asset_maintenance.html
+++ b/asset/templates/asset/asset_maintenance.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Asset Maintenance{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Asset Maintenance</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/asset_mobile.html
+++ b/asset/templates/asset/asset_mobile.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Asset Mobile{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Asset Mobile</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/asset_scan.html
+++ b/asset/templates/asset/asset_scan.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Asset Scan{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Asset Scan</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/asset_transfer.html
+++ b/asset/templates/asset/asset_transfer.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Asset Transfer{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Asset Transfer</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/dashboard.html
+++ b/asset/templates/asset/dashboard.html
@@ -122,19 +122,19 @@ Asset Management Dashboard - {{ request.user.company.company_name|default:"WBEE"
                         <i class="fas fa-bolt me-2"></i>Quick Actions
                     </h5>
                     <div class="d-flex flex-wrap gap-2">
-                        <a href="{% url 'asset' %}" class="btn btn-primary quick-action-btn">
+                        <a href="{% url 'asset:create' %}" class="btn btn-primary quick-action-btn">
                             <i class="fas fa-plus me-1"></i>Add Asset
                         </a>
-                        <a href="{% url 'asset' %}?status=available" class="btn btn-success quick-action-btn">
+                        <a href="{% url 'asset:list' %}?status=available" class="btn btn-success quick-action-btn">
                             <i class="fas fa-search me-1"></i>Find Available
                         </a>
-                        <a href="{% url 'asset' %}" class="btn btn-warning quick-action-btn">
+                        <a href="{% url 'asset:maintenance:schedule' %}" class="btn btn-warning quick-action-btn">
                             <i class="fas fa-calendar me-1"></i>Schedule Maintenance
                         </a>
-                        <a href="{% url 'asset' %}" class="btn btn-info quick-action-btn">
+                        <a href="{% url 'asset:bulk-update' %}" class="btn btn-info quick-action-btn">
                             <i class="fas fa-edit me-1"></i>Bulk Update
                         </a>
-                        <a href="{% url 'asset' %}" class="btn btn-secondary quick-action-btn">
+                        <a href="{% url 'asset:export' %}" class="btn btn-secondary quick-action-btn">
                             <i class="fas fa-download me-1"></i>Export Data
                         </a>
                     </div>
@@ -244,7 +244,7 @@ Asset Management Dashboard - {{ request.user.company.company_name|default:"WBEE"
                     <h6 class="m-0">
                         <i class="fas fa-user-check me-2"></i>Recent Assignments
                     </h6>
-                    <a href="{% url 'asset' %}" class="btn btn-sm btn-outline-light">View All</a>
+                    <a href="{% url 'asset:assignments:list' %}" class="btn btn-sm btn-outline-light">View All</a>
                 </div>
                 <div class="card-body">
                     {% for assignment in recent_assignments %}
@@ -281,7 +281,7 @@ Asset Management Dashboard - {{ request.user.company.company_name|default:"WBEE"
                     <h6 class="m-0">
                         <i class="fas fa-wrench me-2"></i>Recent Maintenance
                     </h6>
-                    <a href="{% url 'asset' %}" class="btn btn-sm btn-outline-dark">View All</a>
+                    <a href="{% url 'asset:maintenance:list' %}" class="btn btn-sm btn-outline-dark">View All</a>
                 </div>
                 <div class="card-body">
                     {% for maintenance in recent_maintenance %}

--- a/asset/templates/asset/legacy/ladder_list.html
+++ b/asset/templates/asset/legacy/ladder_list.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Ladder List{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Ladder List</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/legacy/power_tool_list.html
+++ b/asset/templates/asset/legacy/power_tool_list.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Power Tool List{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Power Tool List</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/legacy/tester_list.html
+++ b/asset/templates/asset/legacy/tester_list.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Tester List{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Tester List</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/legacy/tool_list.html
+++ b/asset/templates/asset/legacy/tool_list.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Tool List{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Tool List</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/legacy/vehicle_list.html
+++ b/asset/templates/asset/legacy/vehicle_list.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Vehicle List{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Vehicle List</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/maintenance_history.html
+++ b/asset/templates/asset/maintenance_history.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Maintenance History{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Maintenance History</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/maintenance_schedule.html
+++ b/asset/templates/asset/maintenance_schedule.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Maintenance Schedule{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Maintenance Schedule</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}

--- a/asset/templates/asset/reports.html
+++ b/asset/templates/asset/reports.html
@@ -1,0 +1,8 @@
+{% extends 'home/base.html' %}
+{% block title %}Reports{% endblock %}
+{% block content %}
+<div class="container py-4">
+  <h1>Reports</h1>
+  <p class="text-muted">Placeholder template.</p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- fix `get_absolute_url` and update asset template links
- add placeholder templates for missing asset views

## Testing
- `pip install -r requirements.txt`
- `python manage.py check` *(fails: OperationalError: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68585115b9088332a11aa7baf1a5b054