### PR TITLE
Fix project detail reverse URL

### DIFF
--- a/project/models.py
+++ b/project/models.py
@@ -275,7 +275,8 @@ class Project(UUIDModel, TimeStampedModel):
         return f"{self.job_number} - {self.name} ({self.location.name})"
     
     def get_absolute_url(self):
-        return reverse('project-detail', args=[str(self.job_number)])
+        """Return the URL for this project detail view."""
+        return reverse('project:project-detail', kwargs={'job_number': str(self.job_number)})
     
     # Business-specific terminology
     @property


### PR DESCRIPTION
## Summary
- fix reverse URL for Project.get_absolute_url so other apps can link properly

## Testing
- `./manage.py test` *(fails: OperationalError due to missing PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_6858c9b88b348332a97222c8ae201b7b