### PR TITLE
Fix task edit button collapse

### DIFF
--- a/todo/templates/todo/list_detail.html
+++ b/todo/templates/todo/list_detail.html
@@ -14,7 +14,7 @@
 
   {% if list_slug != "mine" %}
     <button class="btn btn-primary" id="AddTaskButton" type="button"
-      data-toggle="collapse" data-target="#AddEditTask">Add Task</button>
+      data-bs-toggle="collapse" data-bs-target="#AddEditTask">Add Task</button>
 
     {# Task edit / new task form #}
     {% include 'todo/include/task_edit.html' %}

--- a/todo/templates/todo/task_detail.html
+++ b/todo/templates/todo/task_detail.html
@@ -22,8 +22,8 @@
         class="btn btn-sm btn-primary"
         id="EditTaskButton"
         type="button"
-        data-toggle="collapse"
-        data-target="#AddEditTask"
+        data-bs-toggle="collapse"
+        data-bs-target="#AddEditTask"
       >
           Edit Task
       </button>


### PR DESCRIPTION
## Summary
- fix Bootstrap collapse attributes for task edit and add

## Testing
- `pytest todo/tests/test_views.py::test_view_task_detail -q` *(fails: Requested setting INSTALLED_APPS...)*

------
https://chatgpt.com/codex/tasks/task_e_6858cb88ad0883328b24cc6e4bb84e02