### PR TITLE
Update Google Maps integration

### DIFF
--- a/location/admin.py
+++ b/location/admin.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.db.models import Sum, Count
 from django.utils import timezone
+from django.conf import settings
 
 from .models import (
     BusinessCategory, ConfigurableChoice, LocationType, Location, 
@@ -412,13 +413,11 @@ class LocationAdmin(admin.ModelAdmin):
         """Display embedded map if coordinates available"""
         if obj.coordinates:
             lat, lng = obj.coordinates
-            # Note: Replace YOUR_API_KEY with actual Google Maps API key
             return format_html(
-                '<div style="background: #f0f0f0; padding: 10px; text-align: center;">'
-                '<p>Map would appear here with Google Maps API key</p>'
-                '<p><a href="https://www.google.com/maps?q={},{}" target="_blank">View on Google Maps</a></p>'
-                '</div>',
-                lat, lng
+                '<iframe width="300" height="200" src="https://www.google.com/maps/embed/v1/place?key={key}&q={lat},{lng}" allowfullscreen></iframe>',
+                key=settings.GOOGLE_MAPS_API_KEY,
+                lat=lat,
+                lng=lng,
             )
         return "No coordinates set"
     coordinates_map.short_description = 'Map Preview'

--- a/location/models.py
+++ b/location/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.urls import reverse
 from django.core.validators import RegexValidator
 from django.contrib.contenttypes.fields import GenericRelation
+from django.conf import settings
 from decimal import Decimal
 import uuid
 
@@ -353,7 +354,7 @@ class Location(UUIDModel, TimeStampedModel):
         """Generate Google Maps embed URL"""
         if self.coordinates:
             lat, lng = self.coordinates
-            return f"https://www.google.com/maps/embed/v1/place?key=YOUR_API_KEY&q={lat},{lng}"
+            return f"https://www.google.com/maps/embed/v1/place?key={settings.GOOGLE_MAPS_API_KEY}&q={lat},{lng}"
         return None
     
     @property

--- a/wbee/settings/base.py
+++ b/wbee/settings/base.py
@@ -20,6 +20,9 @@ SECRET_KEY = config('SECRET_KEY', default='a4$zmm5u_$ao70cmji80*8@8oedg&+mnm)r_a
 DEBUG = config('DEBUG', default=True, cast=bool)
 ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='bb.wbee.app', cast=Csv())
 
+# Google Maps API key
+GOOGLE_MAPS_API_KEY = config('GOOGLE_MAPS_API_KEY', default='AIzaSyBC_8mf34uW13LKTM1fKekn_xL7w_socHE')
+
 # Application definition
 DJANGO_APPS = [
     'grappelli',  # Must be before django.contrib.admin


### PR DESCRIPTION
## Summary
- expose `GOOGLE_MAPS_API_KEY` setting and default to provided key
- use settings in Location model to build Google Maps embed URL
- display map preview in admin with actual API key

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6858d4c0effc8332a1a042e225506645