### PR TITLE
Fix map coordinates formatting

### DIFF
--- a/location/admin.py
+++ b/location/admin.py
@@ -370,6 +370,9 @@ class LocationAdmin(admin.ModelAdmin):
         """Display GPS coordinates"""
         if obj.coordinates:
             lat, lng = obj.coordinates
+            # Ensure values are plain floats to avoid SafeString formatting errors
+            lat = float(lat)
+            lng = float(lng)
             return format_html(
                 '<a href="https://www.google.com/maps?q={},{}" target="_blank">{:.4f}, {:.4f}</a>',
                 lat, lng, lat, lng


### PR DESCRIPTION
## Summary
- force coordinates to floats before formatting in admin

## Testing
- `python -m py_compile location/admin.py`
- `pytest -q` *(fails: Requested setting INSTALLED_APPS, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6858de70a6bc8332b462ad4eb0529c19