### PR TITLE
Fix SafeString format bug in Location admin

### DIFF
--- a/location/admin.py
+++ b/location/admin.py
@@ -375,8 +375,11 @@ class LocationAdmin(admin.ModelAdmin):
             lat = float(lat)
             lng = float(lng)
             return format_html(
-                '<a href="https://www.google.com/maps?q={},{}" target="_blank">{:.4f}, {:.4f}</a>',
-                lat, lng, lat, lng
+                '<a href="https://www.google.com/maps?q={},{}" target="_blank">{}, {}</a>',
+                lat,
+                lng,
+                f"{lat:.4f}",
+                f"{lng:.4f}"
             )
         return "—"
     coordinates_display.short_description = 'GPS Coordinates'


### PR DESCRIPTION
## Summary
- avoid numeric formatting with `format_html` in `coordinates_display`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858e5bd42c48332931c484805799319