### PR TITLE
Fix project scope detail URL

### DIFF
--- a/project/templates/project/project_detail_full.html
+++ b/project/templates/project/project_detail_full.html
@@ -73,7 +73,7 @@
       <div class="card-body">
         {% if scope_list %}
           {% for scope in scope_list %}
-            <a id="link" href="{% url 'scope-detail' scope.id %}"><b>{{ scope.area }}</b></a> - {{ scope.system_type }}
+            <a id="link" href="{% url 'project:scope-detail' scope.id %}"><b>{{ scope.area }}</b></a> - {{ scope.system_type }}
             <ul>
               {% if task_list %}
                 {% for tasklist in task_list %}


### PR DESCRIPTION
## Summary
- fix the `scope-detail` link on the project detail page

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_6858e7e7a88c83328e8cb4d33520dc9a