### PR TITLE
Fix project info variables in todo templates

### DIFF
--- a/todo/templates/todo/list_detail.html
+++ b/todo/templates/todo/list_detail.html
@@ -26,7 +26,11 @@
       <h5>Tasks assigned to me (in all groups)</h5>
     {% else %}
       <h5>{{ view_completed|yesno:"Completed tasks, Tasks" }} in "{{ task_list.name }}"</h5>
-      <h5><a href="{{ task_list.scope.project.get_absolute_url }}">{{ task_list.scope.project.job_num }} - {{ task_list.scope.project.job_name }} - {{ task_list.scope.project.jobsite }}</a></h5>
+      <h5>
+        <a href="{{ task_list.scope.project.get_absolute_url }}">
+          {{ task_list.scope.project.job_number }} - {{ task_list.scope.project.name }} - {{ task_list.scope.project.location }}
+        </a>
+      </h5>
       <p><small><i>In workgroup "{{ task_list.group }}" - drag rows to set priorities.</i></small></p>
     {% endif %}
 
@@ -79,7 +83,11 @@
 
   {% else %}
     <h4>No tasks on this list yet  in "{{ task_list.name }}" (add one!)</h4>
-    <h5><a href="{{ task_list.scope.project.get_absolute_url }}">{{ task_list.scope.project.job_num }} - {{ task_list.scope.project.job_name }} - {{ task_list.scope.project.jobsite }}</a></h5>
+    <h5>
+      <a href="{{ task_list.scope.project.get_absolute_url }}">
+        {{ task_list.scope.project.job_number }} - {{ task_list.scope.project.name }} - {{ task_list.scope.project.location }}
+      </a>
+    </h5>
     {% include 'todo/include/toggle_delete.html' %}
 
   {% endif %}

--- a/todo/templates/todo/list_lists.html
+++ b/todo/templates/todo/list_lists.html
@@ -22,7 +22,7 @@
     <ul class="list-group mb-4">
       {% for task in group.list %}
       <li class="list-group-item d-flex justify-content-between align-items-center">
-        <a href="{{ task.scope.project.get_absolute_url }}">{{ task.scope.project.job_num }}</a> - <a href="{% url 'todo:list_detail' task.id task.slug %}">{{ task.name|truncatechars:35 }}</a> 
+        <a href="{{ task.scope.project.get_absolute_url }}">{{ task.scope.project.job_number }}</a> - <a href="{% url 'todo:list_detail' task.id task.slug %}">{{ task.name|truncatechars:35 }}</a>
         <span class="badge badge-primary badge-pill">{{ task.task_set.count }}</span>
       </li>
       {% endfor %}

--- a/todo/templates/todo/task_detail.html
+++ b/todo/templates/todo/task_detail.html
@@ -76,7 +76,9 @@
       </li>
       <li class="list-group-item">
         <strong>For Project:</strong>
-          <a href="{{ task.task_list.scope.project.get_absolute_url }}">{{ task.task_list.scope.project.job_num }} - {{ task.task_list.scope.project.job_name }} - {{ task.task_list.scope.project.jobsite }}</a>
+          <a href="{{ task.task_list.scope.project.get_absolute_url }}">
+            {{ task.task_list.scope.project.job_number }} - {{ task.task_list.scope.project.name }} - {{ task.task_list.scope.project.location }}
+          </a>
       </li>
     </ul>
   </div>
@@ -91,7 +93,7 @@
     <div class="card mb-3">
       <div class="card-header"><b>Devices</b>
         {% if request.user.staff %}
-          <a href="{% url 'project:device-create' job_number=task.task_list.scope.project.job_num %}"><div class="add_jobsite"> + add</div></a>
+          <a href="{% url 'project:device-create' job_number=task.task_list.scope.project.job_number %}"><div class="add_jobsite"> + add</div></a>
         {% else %}
         {% endif %}
       </div>
@@ -120,7 +122,7 @@
     <div class="card mb-3">
       <div class="card-header"><b>Hardware</b> - <a href="">details</a>
         {% if request.user.staff %}
-          <a href="{% url 'project:hardware-create' job_number=task.task_list.scope.project.job_num %}"><div class="add_jobsite"> + add</div></a>
+          <a href="{% url 'project:hardware-create' job_number=task.task_list.scope.project.job_number %}"><div class="add_jobsite"> + add</div></a>
         {% else %}
         {% endif %}
       </div>
@@ -148,7 +150,7 @@
     <div class="card mb-3">
       <div class="card-header"><b>Software</b> - <a href="">details</a>
         {% if request.user.staff %}
-          <a href="{% url 'project:software-create' job_number=task.task_list.scope.project.job_num %}"><div class="add_jobsite"> + add</div></a>
+          <a href="{% url 'project:software-create' job_number=task.task_list.scope.project.job_number %}"><div class="add_jobsite"> + add</div></a>
         {% else %}
         {% endif %}
       </div>
@@ -176,7 +178,7 @@
     <div class="card mb-3">
       <div class="card-header"><b>License</b> - <a href="">details</a>
         {% if request.user.staff %}
-          <a href="{% url 'project:license-create' job_number=task.task_list.scope.project.job_num %}"><div class="add_jobsite"> + add</div></a>
+          <a href="{% url 'project:license-create' job_number=task.task_list.scope.project.job_number %}"><div class="add_jobsite"> + add</div></a>
         {% else %}
         {% endif %}
       </div>
@@ -204,7 +206,7 @@
     <div class="card mb-3">
       <div class="card-header"><b>Travel</b>
         {% if request.user.staff %}
-          <a href="{% url 'project:travel-create' job_number=task.task_list.scope.project.job_num %}"><div class="add_jobsite"> + add</div></a>
+          <a href="{% url 'project:travel-create' job_number=task.task_list.scope.project.job_number %}"><div class="add_jobsite"> + add</div></a>
         {% else %}
         {% endif %}
       </div>


### PR DESCRIPTION
## Summary
- correct outdated project field references in todo templates
- show project details using `job_number`, `name`, and `location`

## Testing
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_6858ea1d5b348332bb3e7ddfcfae82af