### PR TITLE
Fix department path recursion

### DIFF
--- a/company/models.py
+++ b/company/models.py
@@ -538,10 +538,18 @@ class Department(TimeStampedModel):
     
     @property
     def full_department_path(self):
-        """Get full department hierarchy path"""
-        if self.parent_department:
-            return f"{self.parent_department.full_department_path} > {self.name}"
-        return self.name
+        """Return the department hierarchy path without infinite recursion"""
+        names = []
+        current = self
+        visited = set()
+        while current is not None:
+            if current.pk in visited:
+                # Break on cycles to avoid infinite recursion
+                break
+            names.append(current.name)
+            visited.add(current.pk)
+            current = current.parent_department
+        return " > ".join(reversed(names))
 
 # Company settings model for system-wide configurations
 class CompanySettings(TimeStampedModel):

--- a/company/tests.py
+++ b/company/tests.py
@@ -1,3 +1,23 @@
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Company, Department
+
+
+class DepartmentModelTests(TestCase):
+    """Tests for the Department model."""
+
+    def test_full_department_path_handles_cycles(self):
+        """full_department_path should not recurse infinitely on cycles."""
+        company = Company.objects.create(company_name="ACME")
+        dept = Department.objects.create(company=company, name="Ops")
+        # Introduce a cycle where the department is its own parent
+        dept.parent_department = dept
+        dept.save()
+
+        # Accessing full_department_path should not raise RecursionError
+        try:
+            path = dept.full_department_path
+        except RecursionError:
+            self.fail("full_department_path raised RecursionError with a cycle")
+
+        self.assertIn("Ops", path)


### PR DESCRIPTION
## Summary
- avoid infinite recursion in `Department.full_department_path`
- add regression test for cycle in department hierarchy

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test company`

------
https://chatgpt.com/codex/tasks/task_e_6858edc77b048332908d0bbfc32121f5