### PR TITLE
Fix missing template filters

### DIFF
--- a/asset/templatetags/math_filters.py
+++ b/asset/templatetags/math_filters.py
@@ -13,3 +13,27 @@ def sub(value, arg):
         except (TypeError, ValueError):
             return 0
 
+
+@register.filter
+def mul(value, arg):
+    """Multiply the value by the arg."""
+    try:
+        return value * arg
+    except TypeError:
+        try:
+            return float(value) * float(arg)
+        except (TypeError, ValueError):
+            return 0
+
+
+@register.filter
+def div(value, arg):
+    """Divide the value by the arg."""
+    try:
+        return value / arg
+    except (TypeError, ZeroDivisionError):
+        try:
+            return float(value) / float(arg)
+        except (TypeError, ValueError, ZeroDivisionError):
+            return 0
+

--- a/client/templates/client/client_financial_dashboard.html
+++ b/client/templates/client/client_financial_dashboard.html
@@ -1,5 +1,6 @@
 {% extends "home/base.html" %}
 {% load static %}
+{% load math_filters %}
 
 {% block title %}
 {{ client.company_name }} - Financial Dashboard

--- a/location/templates/location/dashboard.html
+++ b/location/templates/location/dashboard.html
@@ -1,6 +1,7 @@
 {% extends "home/base.html" %}
 {% load static %}
 {% load humanize %}
+{% load math_filters %}
 
 {% block title %}Location Dashboard{% endblock %}
 


### PR DESCRIPTION
## Summary
- add `mul` and `div` filters alongside existing `sub`
- load `math_filters` in the client financial and location dashboard templates

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'decouple')*

------
https://chatgpt.com/codex/tasks/task_e_6858f6410d888332be4df9370d277e22