### PR TITLE
Fix project create page permission

### DIFF
--- a/project/views.py
+++ b/project/views.py
@@ -550,12 +550,11 @@ class ProjectDetailView(ProjectAccessMixin, DetailView):
         
         return sorted(activities, key=lambda x: x['date'], reverse=True)[:10]
 
-class ProjectCreateView(LoginRequiredMixin, ProjectPermissionMixin, AjaxResponseMixin, CreateView):
+class ProjectCreateView(LoginRequiredMixin, AjaxResponseMixin, CreateView):
     """Create new project with business logic validation"""
     model = Project
     form_class = ProjectForm
     template_name = 'project/project_form.html'
-    permission_required = 'project.add_project'
     
     # ProjectForm does not accept a custom 'user' argument. Simply
     # return the default kwargs provided by the generic view.


### PR DESCRIPTION
## Summary
- loosen restrictions on ProjectCreateView so authenticated users can open the form
- keep permission requirements for project duplication

## Testing
- `pip install -r requirements.txt`
- `python manage.py check` *(fails: connection to PostgreSQL refused)*

------
https://chatgpt.com/codex/tasks/task_e_6858f6aec418833288d1d9544822cc8f