### PR TITLE
Fix timezone import in Location detail view

### DIFF
--- a/location/views.py
+++ b/location/views.py
@@ -18,6 +18,7 @@ from django.contrib.auth.mixins import (
     UserPassesTestMixin,
     PermissionRequiredMixin,
 )
+from django.utils import timezone
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_http_methods
 import csv


### PR DESCRIPTION
## Summary
- import `timezone` in location views so follow-up notes filter works without error

## Testing
- `DJANGO_SETTINGS_MODULE=wbee.settings.settings_test python manage.py test` *(fails: helpdesk models not registered)*

------
https://chatgpt.com/codex/tasks/task_e_6858fb83774c83329089cf3b49938ff4