### PR TITLE
Add project schedule view

### DIFF
--- a/home/templates/home/home.html
+++ b/home/templates/home/home.html
@@ -245,6 +245,16 @@
         </a>
     </div>
     <div class="col">
+        <a href="{% url 'project:project-schedule' %}" class="text-decoration-none">
+            <div class="card text-center h-100">
+                <div class="card-body">
+                    <i class="fas fa-calendar fa-2x mb-2 text-info"></i>
+                    <div>Schedule</div>
+                </div>
+            </div>
+        </a>
+    </div>
+    <div class="col">
         <a href="{% url 'todo:lists' %}" class="text-decoration-none">
             <div class="card text-center h-100">
                 <div class="card-body">
@@ -288,6 +298,7 @@
         <li><a class="dropdown-item" href="{% url 'asset:list' %}"><i class="fas fa-toolbox me-2 text-warning"></i>Assets</a></li>
         <li><a class="dropdown-item" href="{% url 'hr:worker-list' %}"><i class="fas fa-users me-2 text-success"></i>Staff</a></li>
         <li><a class="dropdown-item" href="{% url 'timecard:list' %}"><i class="fas fa-clock me-2 text-danger"></i>Time Cards</a></li>
+        <li><a class="dropdown-item" href="{% url 'project:project-schedule' %}"><i class="fas fa-calendar me-2 text-info"></i>Schedule</a></li>
         <li><a class="dropdown-item" href="{% url 'todo:lists' %}"><i class="fas fa-tasks me-2 text-primary"></i>Todo</a></li>
         <li><a class="dropdown-item" href="{% url 'receipts:list' %}"><i class="fas fa-receipt me-2 text-secondary"></i>Receipts</a></li>
         <li><a class="dropdown-item" href="{% url 'wip:list' %}"><i class="fas fa-balance-scale me-2 text-warning"></i>WIP</a></li>

--- a/home/views.py
+++ b/home/views.py
@@ -98,11 +98,15 @@ def load_scheduled_events(user):
         # Try to load from schedule app
         from schedule.models import Event
         
-        upcoming_events = Event.objects.filter(
-            workers=user,
-            start__gte=timezone.now(),
-            start__lte=timezone.now() + timedelta(days=30)
-        ).order_by('start')[:5]
+        upcoming_events = (
+            Event.objects.filter(
+                Q(workers=user) | Q(lead=user) | Q(creator=user),
+                start__gte=timezone.now(),
+                start__lte=timezone.now() + timedelta(days=30)
+            )
+            .select_related('project')
+            .order_by('start')[:5]
+        )
         
         for event in upcoming_events:
             # Extract job number from title if it exists

--- a/project/templates/project/schedule.html
+++ b/project/templates/project/schedule.html
@@ -1,0 +1,34 @@
+{% extends "home/base.html" %}
+{% load static %}
+{% block title %}Schedule{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h1 class="h3 mb-0">My Schedule</h1>
+</div>
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Title</th>
+        <th>Project</th>
+        <th>Location</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for e in events %}
+      <tr>
+        <td>{{ e.start|date:"M d, Y g:i A" }}</td>
+        <td>{{ e.title }}</td>
+        <td>{% if e.project %}<a href="{% url 'project:project-detail' e.project.job_number %}">{{ e.project.name }}</a>{% else %}-{% endif %}</td>
+        <td>{{ e.location|default:"" }}</td>
+      </tr>
+      {% empty %}
+      <tr>
+        <td colspan="4" class="text-center">No upcoming events.</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/project/tests.py
+++ b/project/tests.py
@@ -1,3 +1,19 @@
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
+from django.contrib.auth import get_user_model
+from .views import ProjectScheduleView
+import types, sys
+from unittest.mock import MagicMock
 
-# Create your tests here.
+class ScheduleViewTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(email='tester@example.com', password='pass')
+        self.factory = RequestFactory()
+
+    def test_schedule_view_renders(self):
+        request = self.factory.get('/schedule/')
+        request.user = self.user
+        dummy_event = MagicMock()
+        dummy_event.objects.filter.return_value.select_related.return_value.order_by.return_value.__getitem__.return_value = []
+        sys.modules['schedule.models'] = types.SimpleNamespace(Event=dummy_event)
+        response = ProjectScheduleView.as_view()(request)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary
- modernize scheduled events loader for dashboard
- add schedule quick link on the dashboard cards and dropdown
- implement ProjectScheduleView to list upcoming events
- add basic schedule template
- include simple tests for the new view

## Testing
- `DJANGO_SETTINGS_MODULE=wbee.settings.settings_test pytest project/tests.py -q`
- `DJANGO_SETTINGS_MODULE=wbee.settings.settings_test pytest -q` *(fails: helpdesk and schedule apps missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859d890172483328235274cc147027f