### PR TITLE
Add button and breadcrumbs to schedule

### DIFF
--- a/project/templates/project/schedule.html
+++ b/project/templates/project/schedule.html
@@ -1,9 +1,14 @@
 {% extends "home/base.html" %}
 {% load static %}
 {% block title %}Schedule{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'project:dashboard' %}">Projects</a></li>
+<li class="breadcrumb-item active">Schedule</li>
+{% endblock %}
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
   <h1 class="h3 mb-0">My Schedule</h1>
+  <a href="{% url 'create-event' proj=0 %}" class="btn btn-primary"><i class="fas fa-plus"></i> Add Event</a>
 </div>
 <div class="table-responsive">
   <table class="table table-striped">


### PR DESCRIPTION
## Summary
- add breadcrumbs for the project schedule page
- add "+ Event" button to create new events

## Testing
- `pytest -q` *(fails: ImproperlyConfigured settings)*

------
https://chatgpt.com/codex/tasks/task_e_6859f1fc70488332922a04934a78c6b8