### PR TITLE
Fix schedule namespace references

### DIFF
--- a/schedule/templates/schedule/create_event.html
+++ b/schedule/templates/schedule/create_event.html
@@ -4,7 +4,7 @@
 
 {% block title %}Event Update {% endblock %}
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>
+<li class="breadcrumb-item"><a href="{% url 'schedule:schedule' %}">Schedule</a></li>
 <li class="breadcrumb-item active">Update Event info</li>
 {% endblock %}
 

--- a/schedule/templates/schedule/dayevent_detail.html
+++ b/schedule/templates/schedule/dayevent_detail.html
@@ -3,7 +3,7 @@
 {% block title %}Day event details{% endblock %}
 
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>
+<li class="breadcrumb-item"><a href="{% url 'schedule:schedule' %}">Schedule</a></li>
 <li class="breadcrumb-item active">Day event detail</li>
 {% endblock %}
 

--- a/schedule/templates/schedule/edit_occurrence.html
+++ b/schedule/templates/schedule/edit_occurrence.html
@@ -3,7 +3,7 @@
 
 {% block title %}Event Update {% endblock %}
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>
+<li class="breadcrumb-item"><a href="{% url 'schedule:schedule' %}">Schedule</a></li>
 <li class="breadcrumb-item active">Update Event info</li>
 {% endblock %}
 

--- a/schedule/templates/schedule/event.html
+++ b/schedule/templates/schedule/event.html
@@ -4,7 +4,7 @@
 {% block title %}Day event details{% endblock %}
 
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>
+<li class="breadcrumb-item"><a href="{% url 'schedule:schedule' %}">Schedule</a></li>
 <li class="breadcrumb-item active">Day event detail</li>
 {% endblock %}
 

--- a/schedule/templates/schedule/event_archive_day.html
+++ b/schedule/templates/schedule/event_archive_day.html
@@ -4,7 +4,7 @@
 {% block title %}Schedule{% endblock %}
 {% block styler %}<link href="{% static 'home/vendor/datatables/dataTables.bootstrap4.css' %}" rel="stylesheet" type="text/css"> {% endblock %}
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>
+<li class="breadcrumb-item"><a href="{% url 'schedule:schedule' %}">Schedule</a></li>
 <li class="breadcrumb-item active"><b>{{ day }}</b></li>
 {% if request.user.staff %}
 <li class="breadcrumb-item"><a href="{% url 'create-event' proj=0 %}">add a new event</a></li>

--- a/schedule/templates/schedule/event_form.html
+++ b/schedule/templates/schedule/event_form.html
@@ -4,7 +4,7 @@
 
 {% block title %}Event Update {% endblock %}
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>
+<li class="breadcrumb-item"><a href="{% url 'schedule:schedule' %}">Schedule</a></li>
 <li class="breadcrumb-item active">Update Event info</li>
 {% endblock %}
 

--- a/schedule/templates/schedule/schedule_day_list.html
+++ b/schedule/templates/schedule/schedule_day_list.html
@@ -3,7 +3,7 @@
 {% block title %}Schedule{% endblock %}
 {% block styler %}<link href="{% static 'home/vendor/datatables/dataTables.bootstrap4.css' %}" rel="stylesheet" type="text/css"> {% endblock %}
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>
+<li class="breadcrumb-item"><a href="{% url 'schedule:schedule' %}">Schedule</a></li>
 <li class="breadcrumb-item active"><b>{{ now|date:"F, jS o" }}</b></li>
 {% if request.user.staff %}
 <li class="breadcrumb-item"><a href="{% url 'create-event' proj=dayevent.project.job_num %}">add a new event</a></li>

--- a/timecard/templates/scheduling_timecard.html
+++ b/timecard/templates/scheduling_timecard.html
@@ -2,7 +2,7 @@
 
 {% block title %}Time card{% endblock %}
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'schedule' %}">Schedule</a></li>
+<li class="breadcrumb-item"><a href="{% url 'schedule:schedule' %}">Schedule</a></li>
 <li class="breadcrumb-item active">Time card / TODAY IS {{ tadai }}</li>
 {% if request.user.staff %}
 <li class="breadcrumb-item"><a href="{% url 'create-timecard' %}">add a new day</a></li>


### PR DESCRIPTION
## Summary
- use correct namespace in schedule breadcrumbs

## Testing
- `python manage.py check`
- `python manage.py test schedule.tests` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6859f3797e34833299e2ab4dc60847fb