### PR TITLE
Fix calendar template links

### DIFF
--- a/schedule/templates/schedule/calendar.html
+++ b/schedule/templates/schedule/calendar.html
@@ -13,14 +13,9 @@
 <p>{% trans "Event count:" %} {{events_count}} </p>
 
 <div>
-    <p>{% trans "See as:" %}</p>
+    <p>{% trans "View" %}</p>
     <ul>
-        <li><a href="{% url "compact_calendar" calendar.slug %}">{% trans "Small Month" %}</a></li>
-        <li><a href="{% url "month_calendar" calendar.slug %}">{% trans "1 Month" %}</a></li>
-        <li><a href="{% url "tri_month_calendar" calendar.slug %}">{% trans "3 Months" %}</a></li>
-        <li><a href="{% url "year_calendar" calendar.slug %}">{% trans "This Year" %}</a></li>
-        <li><a href="{% url "week_calendar" calendar.slug %}">{% trans "Weekly" %}</a></li>
-        <li><a href="{% url "day_calendar" calendar.slug %}">{% trans "Daily" %}</a></li>
+        <li><a href="{% url 'schedule:calendar-detail' calendar.slug %}">{% trans "Calendar Overview" %}</a></li>
     </ul>
 </div>
 

--- a/schedule/templates/schedule/calendar_list.html
+++ b/schedule/templates/schedule/calendar_list.html
@@ -6,12 +6,8 @@
 <ul>
 {% for cal in object_list %}
 <li><b>{{ cal }}</b> :
-  <a href="{% url "compact_calendar" cal.slug %}">{% trans "Small Month" %}</a> --
-  <a href="{% url "month_calendar" cal.slug %}">{% trans "1 Month" %}</a> --
-  <a href="{% url "tri_month_calendar" cal.slug %}">{% trans "3 Months" %}</a> --
-  <a href="{% url "year_calendar" cal.slug %}">{% trans "This Year" %}</a> --
-  <a href="{% url "week_calendar" cal.slug %}">{% trans "Weekly" %}</a> --
-  <a href="{% url "day_calendar" cal.slug %}">{% trans "Daily" %}</a></li><br>
+  <a href="{% url 'schedule:calendar-detail' cal.slug %}">{% trans "View Calendar" %}</a>
+</li><br>
 {% endfor %}
 </ul>
 {% endblock %}


### PR DESCRIPTION
## Summary
- fix references to nonexistent views in calendar list and detail templates

## Testing
- `python manage.py test` *(fails: connection to server at "localhost" (::1), port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a0ea201848332afbf381f8d815d7b