### PR TITLE
Fix event time comparisons with None values

### DIFF
--- a/schedule/schedule_models.py
+++ b/schedule/schedule_models.py
@@ -600,17 +600,23 @@ class Event(TimeStampedModel):
     @property
     def is_past(self):
         """Check if event is in the past"""
+        if not self.end:
+            return False
         return self.end < timezone.now()
 
     @property
     def is_current(self):
         """Check if event is currently happening"""
+        if not self.start or not self.end:
+            return False
         now = timezone.now()
         return self.start <= now <= self.end
 
     @property
     def is_upcoming(self):
         """Check if event is upcoming"""
+        if not self.start:
+            return False
         return self.start > timezone.now()
 
     @property


### PR DESCRIPTION
## Summary
- ensure event helpers handle missing start or end times

## Testing
- `pip install -r requirements.txt`
- `pytest schedule/tests/test_ical_feed.py::ICalFeedTests::test_ical_feed_returns_200 -q` *(fails: NOT NULL constraint failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a1e1a2e7483329aa21a16e474b2c8