### PR TITLE
Configure pytest environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DJANGO_SETTINGS_MODULE=wbee.settings.base

--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# Install dependencies
+python -m pip install -r requirements.txt
+
+# Ensure DJANGO_SETTINGS_MODULE is set
+export DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-wbee.settings.base}
+
+# Use SQLite database if DATABASE_URL is not provided
+export DATABASE_URL=${DATABASE_URL:-sqlite:///db.sqlite3}
+
+# Apply database migrations
+python manage.py migrate --noinput
+
+# Collect static files (optional; uncomment if needed)
+# python manage.py collectstatic --noinput

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  app:
+    image: python:3.11
+    volumes:
+      - .:/app
+    working_dir: /app
+    env_file:
+      - .env
+    command: bash -c "./codex_setup.sh && python manage.py runserver 0.0.0.0:8000"
+    ports:
+      - "8000:8000"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = wbee.settings.base
+python_files = tests.py test_*.py *_tests.py
+addopts = -ra

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import django
+
+
+def pytest_configure():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "wbee.settings.base")
+    django.setup()


### PR DESCRIPTION
## Summary
- add `.env` so Django settings are picked up
- configure pytest with `pytest.ini`
- initialize Django in a top-level `tests/conftest.py`
- provide a convenience `codex_setup.sh` script
- add optional docker-compose configuration

## Testing
- `bash codex_setup.sh`
- `pytest -q` *(fails: helpdesk app not in `INSTALLED_APPS`)*

------
https://chatgpt.com/codex/tasks/task_e_685a26ffea648332a08e3cf9cdba7af4