### PR TITLE
Fix schedule calendar link

### DIFF
--- a/schedule/templates/schedule/calendar.html
+++ b/schedule/templates/schedule/calendar.html
@@ -15,7 +15,7 @@
 <div>
     <p>{% trans "View" %}</p>
     <ul>
-        <li><a href="{% url 'schedule:calendar-detail' calendar.slug %}">{% trans "Calendar Overview" %}</a></li>
+        <li><a href="{% url 'schedule:month_calendar' calendar.slug %}">{% trans "Monthly Calendar" %}</a></li>
     </ul>
 </div>
 

--- a/schedule/urls.py
+++ b/schedule/urls.py
@@ -10,5 +10,6 @@ urlpatterns = [
     path("calendars/", views.CalendarListView.as_view(), name="calendar_list"),
     path("<int:calendar_id>/ical/", CalendarICalendar(), name="calendar-ical"),
     path("event/create/<str:proj>/", views.EventCreateView.as_view(), name="create-event"),
+    path("calendars/<slug:slug>/month/", views.MonthCalendarView.as_view(), name="month_calendar"),
     path("calendars/<slug:slug>/", views.CalendarDetailView.as_view(), name="calendar-detail"),
 ]


### PR DESCRIPTION
## Summary
- add MonthCalendarView to display a monthly calendar view
- route `/calendars/<slug>/month/` to the new view
- update calendar overview template to link to the monthly calendar

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Model class helpdesk.models.base.Queue doesn't declare an explicit app_label)*

------
https://chatgpt.com/codex/tasks/task_e_685a2334f7208332b2429d4e3872d54f