### PR TITLE
Add event links on schedule

### DIFF
--- a/project/templates/project/schedule.html
+++ b/project/templates/project/schedule.html
@@ -1,5 +1,5 @@
 {% extends "home/base.html" %}
-{% load static %}
+{% load static scheduletags %}
 {% block title %}Schedule{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:dashboard' %}">Projects</a></li>
@@ -18,19 +18,21 @@
         <th>Title</th>
         <th>Project</th>
         <th>Location</th>
+        <th>Lead</th>
       </tr>
     </thead>
     <tbody>
       {% for e in events %}
-      <tr>
-        <td>{{ e.start|date:"M d, Y g:i A" }}</td>
-        <td>{{ e.title }}</td>
+      <tr{% if e.is_user_event %} class="table-info"{% endif %}>
+        <td><a href="{% url 'day_calendar' e.calendar.slug %}{% querystring_for_date e.start 3 %}">{{ e.start|date:"M d, Y g:i A" }}</a></td>
+        <td><a href="{{ e.get_absolute_url }}">{{ e.title }}</a></td>
         <td>{% if e.project %}<a href="{% url 'project:project-detail' e.project.job_number %}">{{ e.project.name }}</a>{% else %}-{% endif %}</td>
-        <td>{{ e.location|default:"" }}</td>
+        <td>{% if e.project %}<a href="{{ e.project.location.get_absolute_url }}">{{ e.project.location.name }}</a>{% else %}{{ e.location|default:"" }}{% endif %}</td>
+        <td>{% if e.lead %}<a href="{{ e.lead.get_absolute_url }}">{{ e.lead.get_full_name }}</a>{% else %}-{% endif %}</td>
       </tr>
       {% empty %}
       <tr>
-        <td colspan="4" class="text-center">No upcoming events.</td>
+        <td colspan="5" class="text-center">No upcoming events.</td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary
- highlight user's events on schedule
- link dates to calendar day view
- link titles to event detail
- link location and lead details

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685a2d1018848332ad34315f778fa8c3