### PR TITLE
Fix missing calendar view

### DIFF
--- a/schedule/urls.py
+++ b/schedule/urls.py
@@ -10,6 +10,10 @@ urlpatterns = [
     path("calendars/", views.CalendarListView.as_view(), name="calendar_list"),
     path("<int:calendar_id>/ical/", CalendarICalendar(), name="calendar-ical"),
     path("event/create/<str:proj>/", views.EventCreateView.as_view(), name="create-event"),
+    path("calendars/<slug:slug>/day/", views.DayCalendarView.as_view(), name="day_calendar"),
+    path("calendars/<slug:slug>/week/", views.WeekCalendarView.as_view(), name="week_calendar"),
+    path("calendars/<slug:slug>/year/", views.YearCalendarView.as_view(), name="year_calendar"),
+    path("calendars/<slug:slug>/tri-month/", views.TriMonthCalendarView.as_view(), name="tri_month_calendar"),
     path("calendars/<slug:slug>/month/", views.MonthCalendarView.as_view(), name="month_calendar"),
     path("calendars/<slug:slug>/", views.CalendarDetailView.as_view(), name="calendar-detail"),
 ]

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -6,7 +6,7 @@ from django.http import Http404
 from django.utils import timezone
 import datetime
 
-from .periods import Month, weekday_names
+from .periods import Day, Week, Month, Year, weekday_names
 from .settings import GET_EVENTS_FUNC
 from .models import Event, Calendar
 from .forms import NewEventForm
@@ -103,3 +103,127 @@ class MonthCalendarView(LoginRequiredMixin, DetailView):
             }
         )
         return context
+
+
+class WeekCalendarView(LoginRequiredMixin, DetailView):
+    """Display a weekly calendar view for a specific calendar."""
+
+    model = Calendar
+    template_name = "schedule/calendar_week.html"
+    slug_field = "slug"
+    slug_url_kwarg = "slug"
+    context_object_name = "calendar"
+
+    def _get_date(self):
+        try:
+            parts = {
+                key: int(self.request.GET.get(key))
+                for key in ["year", "month", "day", "hour", "minute", "second"]
+                if self.request.GET.get(key) is not None
+            }
+            if parts:
+                return datetime.datetime(**parts)
+        except ValueError:
+            raise Http404
+        return timezone.now()
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        calendar = self.object
+        date = self._get_date()
+        events = GET_EVENTS_FUNC(self.request, calendar)
+        period = Week(events, date, tzinfo=timezone.get_current_timezone())
+        context.update(
+            {
+                "date": date,
+                "period": period,
+                "calendar": calendar,
+                "weekday_names": weekday_names,
+            }
+        )
+        return context
+
+
+class DayCalendarView(LoginRequiredMixin, DetailView):
+    """Display a daily calendar view for a specific calendar."""
+
+    model = Calendar
+    template_name = "schedule/calendar_day.html"
+    slug_field = "slug"
+    slug_url_kwarg = "slug"
+    context_object_name = "calendar"
+
+    def _get_date(self):
+        try:
+            parts = {
+                key: int(self.request.GET.get(key))
+                for key in ["year", "month", "day", "hour", "minute", "second"]
+                if self.request.GET.get(key) is not None
+            }
+            if parts:
+                return datetime.datetime(**parts)
+        except ValueError:
+            raise Http404
+        return timezone.now()
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        calendar = self.object
+        date = self._get_date()
+        events = GET_EVENTS_FUNC(self.request, calendar)
+        period = Day(events, date, tzinfo=timezone.get_current_timezone())
+        context.update(
+            {
+                "date": date,
+                "period": period,
+                "calendar": calendar,
+                "weekday_names": weekday_names,
+            }
+        )
+        return context
+
+
+class YearCalendarView(LoginRequiredMixin, DetailView):
+    """Display a yearly calendar view for a specific calendar."""
+
+    model = Calendar
+    template_name = "schedule/calendar_year.html"
+    slug_field = "slug"
+    slug_url_kwarg = "slug"
+    context_object_name = "calendar"
+
+    def _get_date(self):
+        try:
+            parts = {
+                key: int(self.request.GET.get(key))
+                for key in ["year", "month", "day", "hour", "minute", "second"]
+                if self.request.GET.get(key) is not None
+            }
+            if parts:
+                return datetime.datetime(**parts)
+        except ValueError:
+            raise Http404
+        return timezone.now()
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        calendar = self.object
+        date = self._get_date()
+        events = GET_EVENTS_FUNC(self.request, calendar)
+        period = Year(events, date, tzinfo=timezone.get_current_timezone())
+        context.update(
+            {
+                "date": date,
+                "period": period,
+                "calendar": calendar,
+                "weekday_names": weekday_names,
+            }
+        )
+        return context
+
+
+class TriMonthCalendarView(MonthCalendarView):
+    """Display a three-month calendar view for a specific calendar."""
+
+    template_name = "schedule/calendar_tri_month.html"
+


### PR DESCRIPTION
## Summary
- add week, day, year, and tri-month calendar views
- expose new calendar period routes

## Testing
- `python -m py_compile schedule/views.py`
- `pytest -q` *(fails: ModuleNotFoundError / OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_685a3182e53083329a0207e3d3000812