### PR TITLE
Fix event detail view

### DIFF
--- a/schedule/urls.py
+++ b/schedule/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("", views.CalendarListView.as_view(), name="schedule"),
     path("calendars/", views.CalendarListView.as_view(), name="calendar_list"),
     path("<int:calendar_id>/ical/", CalendarICalendar(), name="calendar-ical"),
+    path("events/<int:pk>/", views.EventDetailView.as_view(), name="event-detail"),
     path("event/create/<str:proj>/", views.EventCreateView.as_view(), name="create-event"),
     path("calendars/<slug:slug>/day/", views.DayCalendarView.as_view(), name="day_calendar"),
     path("calendars/<slug:slug>/week/", views.WeekCalendarView.as_view(), name="week_calendar"),

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -36,6 +36,14 @@ class EventCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
         return self.object.get_absolute_url()
 
 
+class EventDetailView(LoginRequiredMixin, DetailView):
+    """Display detailed information for a single event."""
+
+    model = Event
+    template_name = "schedule/event.html"
+    context_object_name = "event"
+
+
 class CalendarDetailView(LoginRequiredMixin, DetailView):
     """Display details for a specific calendar."""
 


### PR DESCRIPTION
## Summary
- implement `EventDetailView` and hook URL

## Testing
- `pytest -q` *(fails: RuntimeError - helpdesk models not in INSTALLED_APPS)*

------
https://chatgpt.com/codex/tasks/task_e_685a366142488332855a7e043338e8c8