### PR TITLE
Fix calendar URL reversing

### DIFF
--- a/schedule/templates/schedule/_day_cell.html
+++ b/schedule/templates/schedule/_day_cell.html
@@ -8,7 +8,7 @@
     <td style="color:blue;">
   {% endif %}
   
-  <a style="color:#000;" href="{% url 'day_calendar' calendar.slug %}{% querystring_for_date day.start 3 %}">
+  <a style="color:#000;" href="{% url 'schedule:day_calendar' calendar.slug %}{% querystring_for_date day.start 3 %}">
   <div style="text-align: center;height:100%;width:100%;">
     <strong>{{day.start.day}}</strong>
   </div>

--- a/schedule/templates/schedule/_month_table.html
+++ b/schedule/templates/schedule/_month_table.html
@@ -11,8 +11,8 @@
 <tbody id="calendr-month">
   {% for week in month.get_weeks %}
       <tr>
-      <td style="width:4%;" class="calendr-day">
-          <a href="{% url "week_calendar" calendar.slug %}{% querystring_for_date week.start 3 %}">
+        <td style="width:4%;" class="calendr-day">
+            <a href="{% url "schedule:week_calendar" calendar.slug %}{% querystring_for_date week.start 3 %}">
               <i class="fa fa-calendar-plus-o" aria-hidden="true"></i>
           </a>
       </td>

--- a/schedule/templates/schedule/calendar_day.html
+++ b/schedule/templates/schedule/calendar_day.html
@@ -12,22 +12,22 @@
 {% include "schedule/_dialogs.html" %}
 <div class="row row-centered">
  <div class="col">
-    <a class="btn btn-primary gradient" href="{% url "day_calendar" calendar.slug %}">
+    <a class="btn btn-primary gradient" href="{% url "schedule:day_calendar" calendar.slug %}">
       {% trans "Today" %}
     </a>
-  <a class="btn btn-primary gradient" href="{% url "week_calendar" calendar.slug %}{% querystring_for_date period.start 3 %}">
+  <a class="btn btn-primary gradient" href="{% url "schedule:week_calendar" calendar.slug %}{% querystring_for_date period.start 3 %}">
     {% trans "Week" %}
   </a>
  </div>
  <div class="col">
-  {% prevnext "day_calendar" calendar period "l, F d, Y" %}
+  {% prevnext "schedule:day_calendar" calendar period "l, F d, Y" %}
  </div>
  <div class="col">
   <div style="float: right;">
-  <a class="btn btn-primary gradient" href="{% url "month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
+  <a class="btn btn-primary gradient" href="{% url "schedule:month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
     {% trans "Month" %}
   </a>
-  <a class="btn btn-primary gradient" href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
+  <a class="btn btn-primary gradient" href="{% url "schedule:year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
     {% trans "Year" %}
   </a></div>
  </div>

--- a/schedule/templates/schedule/calendar_month.html
+++ b/schedule/templates/schedule/calendar_month.html
@@ -25,12 +25,12 @@
    <div class="card sched_container scheduler_month">
    <div class="row sched_navline" style="width: 100%;">
     <div class="col">
-      <a href="{% url "day_calendar" calendar.slug %}"><div class="btn-custom sched_tab sched_tab_first" name="day_tab">{% trans "Day" %}</div></a>
-      <a href="{% url "week_calendar" calendar.slug %}"><div class="btn-custom sched_tab" name="week_tab">{% trans "Week" %}</div></a>
-      <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}"><div class="btn-custom sched_tab active" name="month_tab">{% trans "Month" %}</div></a>
-      <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}"><div class="btn-custom sched_tab sched_tab_last" name="month_tab">{% trans "Year" %}</div></a>
+      <a href="{% url "schedule:day_calendar" calendar.slug %}"><div class="btn-custom sched_tab sched_tab_first" name="day_tab">{% trans "Day" %}</div></a>
+      <a href="{% url "schedule:week_calendar" calendar.slug %}"><div class="btn-custom sched_tab" name="week_tab">{% trans "Week" %}</div></a>
+      <a href="{% url "schedule:month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}"><div class="btn-custom sched_tab active" name="month_tab">{% trans "Month" %}</div></a>
+      <a href="{% url "schedule:year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}"><div class="btn-custom sched_tab sched_tab_last" name="month_tab">{% trans "Year" %}</div></a>
     </div>
-    <div class="col sched_date"><span class="month_head">{% prevnext "month_calendar" calendar period "F Y"%}</span></div>
+    <div class="col sched_date"><span class="month_head">{% prevnext "schedule:month_calendar" calendar period "F Y"%}</span></div>
     <div class="col sched_date"><span class="month_head"><div class="calendarname">{{ calendar.name }}</div></span></div>
   </div>
  
@@ -41,10 +41,10 @@
         </div>
       </div>
       <div class="row-centered">
-        <a href="{% url "tri_month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
+        <a href="{% url "schedule:tri_month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
           {% trans "Three Month Calendar" %}
         </a>
-        <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
+        <a href="{% url "schedule:year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
           {% trans "Full Year Calendar" %}
         </a>
     </div>

--- a/schedule/templates/schedule/calendar_tri_month.html
+++ b/schedule/templates/schedule/calendar_tri_month.html
@@ -9,9 +9,9 @@
 
 {% block content %}
 <div class="tablewrapper">
-  {% prevnext "tri_month_calendar" calendar period "F Y"%}
+  {% prevnext "schedule:tri_month_calendar" calendar period "F Y"%}
   <div class="now">
-    <a href="{% url "tri_month_calendar" calendar.slug %}">
+  <a href="{% url "schedule:tri_month_calendar" calendar.slug %}">
       {% trans "This month" %}
     </a>
   </div>
@@ -26,10 +26,10 @@
 </table>
 </div>
 <div class="navigation">
-  <a href="{% url "month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
+  <a href="{% url "schedule:month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
     {% trans "Monthly Calendar" %}
   </a>
-  <a href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
+  <a href="{% url "schedule:year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
     {% trans "Full Year Calendar" %}
   </a>
 </div>

--- a/schedule/templates/schedule/calendar_week.html
+++ b/schedule/templates/schedule/calendar_week.html
@@ -11,19 +11,19 @@
 
 <div class="row row-centered">
   <div class="col">
-    <a class="btn btn-primary gradient" href="{% url "month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
+    <a class="btn btn-primary gradient" href="{% url "schedule:month_calendar" calendar.slug %}{% querystring_for_date period.start 2 %}">
       {% trans "Month" %}
     </a>
-    <a class="btn btn-primary gradient" href="{% url "year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
+    <a class="btn btn-primary gradient" href="{% url "schedule:year_calendar" calendar.slug %}{% querystring_for_date period.start 1 %}">
       {% trans "Year" %}
     </a>
   </div>
   <div class="col">
-    {{ calendar.name }} {% prevnext "week_calendar" calendar period "\W\e\ek W, M Y" %}
+    {{ calendar.name }} {% prevnext "schedule:week_calendar" calendar period "\W\e\ek W, M Y" %}
   </div>
   <div class="col">
     <div class="now">
-      <a class="btn btn-primary gradient" href="{% url "week_calendar" calendar.slug %}">
+      <a class="btn btn-primary gradient" href="{% url "schedule:week_calendar" calendar.slug %}">
         {% trans "This week" %}
       </a>
     </div>
@@ -33,7 +33,7 @@
   {% for day in period.get_days %}
     <div class="col-md-3">
       <div class="row row-centered">
-        <a class="btn btn-primary gradient" href="{% url "day_calendar" calendar.slug %}{% querystring_for_date day.start 3 %}">
+        <a class="btn btn-primary gradient" href="{% url "schedule:day_calendar" calendar.slug %}{% querystring_for_date day.start 3 %}">
           {{day.start|date:"l, d"}}
         </a>
       </div>

--- a/schedule/templates/schedule/calendar_year.html
+++ b/schedule/templates/schedule/calendar_year.html
@@ -7,12 +7,12 @@
 
 <div class="tablewrapper">
     <div class="calendarname">{{ calendar.name }}</div>
-    {% prevnext "year_calendar" calendar period "Y" %}
+      {% prevnext "schedule:year_calendar" calendar period "Y" %}
     <div class="content">
       {% for month in period.get_months %}
         <div class="col-md-3" style="margin-bottom:10px;">
           <div class="row row-centered">
-            <button class="btn btn-custom active" href="{% url "month_calendar" calendar.slug %}{% querystring_for_date month.start 2 %}">{{month.name}}</button>
+              <button class="btn btn-custom active" href="{% url "schedule:month_calendar" calendar.slug %}{% querystring_for_date month.start 2 %}">{{month.name}}</button>
           </div>
           <div>
             {% month_table calendar month "small" %}
@@ -21,10 +21,10 @@
       {% endfor %}
     </div>
 <div class="navigation">
-  <a href="{% url "month_calendar" calendar.slug %}">
+    <a href="{% url "schedule:month_calendar" calendar.slug %}">
     {% trans "Current Month Calendar" %}
   </a>
-  <a href="{% url "year_calendar" calendar.slug %}">
+    <a href="{% url "schedule:year_calendar" calendar.slug %}">
     {% trans "Current Year Calendar" %}
   </a>
 </div>

--- a/schedule/templates/schedule/event.html
+++ b/schedule/templates/schedule/event.html
@@ -137,13 +137,13 @@
         </div>
       </div>
     <div class="col-lg-6">
-      <a class="btn btn-primary gradient" href="{% url "day_calendar" event.calendar.slug %}{% querystring_for_date event.start 3 %}">
+        <a class="btn btn-primary gradient" href="{% url "schedule:day_calendar" event.calendar.slug %}{% querystring_for_date event.start 3 %}">
         {% trans "Day" %}
       </a>
-      <a class="btn btn-primary gradient" href="{% url "month_calendar" event.calendar.slug %}{% querystring_for_date event.start 2 %}">
+        <a class="btn btn-primary gradient" href="{% url "schedule:month_calendar" event.calendar.slug %}{% querystring_for_date event.start 2 %}">
         {% trans "Month" %}
       </a>
-      <a class="btn btn-primary gradient" href="{% url "year_calendar" event.calendar.slug %}{% querystring_for_date event.start 1 %}">
+        <a class="btn btn-primary gradient" href="{% url "schedule:year_calendar" event.calendar.slug %}{% querystring_for_date event.start 1 %}">
         {% trans "Year" %}
       </a>
     </div>

--- a/schedule/templates/schedule/occurrence.html
+++ b/schedule/templates/schedule/occurrence.html
@@ -5,13 +5,13 @@
 
 {% block body %}
 <div class="navigation">
-  <a class="btn btn-primary gradient" href="{% url "day_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 3 %}">
+  <a class="btn btn-primary gradient" href="{% url "schedule:day_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 3 %}">
     {% trans "Day" %}
   </a>
-  <a class="btn btn-primary gradient" href="{% url "month_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 2 %}">
+  <a class="btn btn-primary gradient" href="{% url "schedule:month_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 2 %}">
     {% trans "Month" %}
   </a>
-  <a class="btn btn-primary gradient" href="{% url "year_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 1 %}">
+  <a class="btn btn-primary gradient" href="{% url "schedule:year_calendar" occurrence.event.calendar.slug %}{% querystring_for_date occurrence.start 1 %}">
     {% trans "Year" %}
   </a>
 </div>

--- a/schedule/templates/schedule/schedule_day_list.html
+++ b/schedule/templates/schedule/schedule_day_list.html
@@ -12,13 +12,13 @@
 
 {% block content %}
   <div class="col-lg-6">
-    <a class="btn btn-primary gradient" href="{% url "day_calendar" event.calendar.slug %}{% querystring_for_date event.start 3 %}">
+      <a class="btn btn-primary gradient" href="{% url "schedule:day_calendar" event.calendar.slug %}{% querystring_for_date event.start 3 %}">
       {% trans "Day" %}
     </a>
-    <a class="btn btn-primary gradient" href="{% url "month_calendar" event.calendar.slug %}{% querystring_for_date event.start 2 %}">
+      <a class="btn btn-primary gradient" href="{% url "schedule:month_calendar" event.calendar.slug %}{% querystring_for_date event.start 2 %}">
       {% trans "Month" %}
     </a>
-    <a class="btn btn-primary gradient" href="{% url "year_calendar" event.calendar.slug %}{% querystring_for_date event.start 1 %}">
+      <a class="btn btn-primary gradient" href="{% url "schedule:year_calendar" event.calendar.slug %}{% querystring_for_date event.start 1 %}">
       {% trans "Year" %}
     </a>
   </div>


### PR DESCRIPTION
## Summary
- namespace schedule URL links in templates

## Testing
- `pytest -q` *(fails: Model class helpdesk.models.base.Queue doesn't declare an explicit app_label)*

------
https://chatgpt.com/codex/tasks/task_e_685a3ac10c988332bdbf67c60064f142