### PR TITLE
Fix missing calendar_create_event url

### DIFF
--- a/schedule/urls.py
+++ b/schedule/urls.py
@@ -11,6 +11,11 @@ urlpatterns = [
     path("<int:calendar_id>/ical/", CalendarICalendar(), name="calendar-ical"),
     path("events/<int:pk>/", views.EventDetailView.as_view(), name="event-detail"),
     path("event/create/<str:proj>/", views.EventCreateView.as_view(), name="create-event"),
+    path(
+        "calendars/<slug:slug>/create-event/",
+        views.EventCreateView.as_view(),
+        name="calendar_create_event",
+    ),
     path("calendars/<slug:slug>/day/", views.DayCalendarView.as_view(), name="day_calendar"),
     path("calendars/<slug:slug>/week/", views.WeekCalendarView.as_view(), name="week_calendar"),
     path("calendars/<slug:slug>/year/", views.YearCalendarView.as_view(), name="year_calendar"),

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -30,6 +30,10 @@ class EventCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
             project = Project.objects.filter(job_number=proj).first()
             if project:
                 initial["project"] = project
+        slug = self.kwargs.get("slug")
+        if slug:
+            calendar = get_object_or_404(Calendar, slug=slug)
+            initial["calendar"] = calendar
         return initial
 
     def get_success_url(self):


### PR DESCRIPTION
## Summary
- add missing `calendar_create_event` route in schedule URLs
- auto-fill calendar field when creating events from a calendar

## Testing
- `pytest -q` *(fails: Model class helpdesk.models.base.Queue doesn't declare an explicit app_label)*

------
https://chatgpt.com/codex/tasks/task_e_685a3ec50320833282ee49e9dcc8ee87