### PR TITLE
Show scheduled work on project detail

### DIFF
--- a/project/templates/project/project_detail_full.html
+++ b/project/templates/project/project_detail_full.html
@@ -100,9 +100,9 @@
   </div>
   <div class="col-lg-4">
     <div class="card mb-3">
-      <div class="card-header" style="background-color:rgb(0, 119, 255);"><b>Scheduled days</b>
+      <div class="card-header" style="background-color:rgb(0, 119, 255);"><b>Scheduled Work</b>
         {% if request.user.is_staff %}
-          <a href="{% url 'create-event' proj=project.job_number %}"><div class="add_jobsite"> + add</div></a>
+          <a href="{% url 'create-event' proj=project.job_number %}"><div class="add_jobsite"> + add work</div></a>
         {% endif %}
       </div>
       {% if scheduling_event_list %}

--- a/project/views.py
+++ b/project/views.py
@@ -465,6 +465,15 @@ class ProjectDetailView(ProjectAccessMixin, DetailView):
             target_date__gte=date.today(),
             is_complete=False
         ).order_by('target_date')[:5]
+
+        # Scheduled events for this project
+        from schedule.models import Event
+        upcoming_events = Event.objects.filter(
+            project=project
+        ).select_related('lead').order_by('start')
+        context['scheduling_event_list'] = upcoming_events
+        context['event_time'] = sum((e.duration_hours for e in upcoming_events), 0)
+
         
         # Team information
         context['team_info'] = {


### PR DESCRIPTION
## Summary
- fetch project's scheduled events in view
- show "Scheduled Work" section with an "add work" button and list events

## Testing
- `pytest -q` *(fails: helpdesk app missing in INSTALLED_APPS)*

------
https://chatgpt.com/codex/tasks/task_e_685a3f5cfad08332a5c6d95555277d57