### PR TITLE
Fix reversed URL for event creation

### DIFF
--- a/schedule/templates/fullcalendar.html
+++ b/schedule/templates/fullcalendar.html
@@ -18,7 +18,7 @@
                 {% endfor %}
             </ul>
         {% endif %}
-<a class="btn btn-primary gradient" href="{% url 'calendar_create_event' calendar_slug %}">
+<a class="btn btn-primary gradient" href="{% url 'schedule:calendar_create_event' calendar_slug %}">
     <span class='glyphicon glyphicon-plus'></span>
     {% trans "Add New Session" %}
 </a>

--- a/schedule/templates/profiles/schedule.html
+++ b/schedule/templates/profiles/schedule.html
@@ -50,12 +50,12 @@
     </tbody>
 </table>
 {% else %}
-    {% url "calendar_create_event" as add_event_url %}
+    {% url "schedule:calendar_create_event" as add_event_url %}
     <p>{% blocktrans %}You haven't added any <a href="{{ add_event_url }}">event</a> yet.{% endblocktrans %}</p>
 {% endif %}
 
 <p>
-    <a href="{% url "calendar_create_event" calendar %}">{% block schedule_add_event_link_label %}{% trans "Add event" %}{% endblock %}</a>
+    <a href="{% url "schedule:calendar_create_event" calendar %}">{% block schedule_add_event_link_label %}{% trans "Add event" %}{% endblock %}</a>
 </p>
 
 {% endblock %}

--- a/schedule/templatetags/scheduletags.py
+++ b/schedule/templatetags/scheduletags.py
@@ -107,7 +107,7 @@ def create_event_url(context, calendar, slot):
         'slug': calendar.slug,
     }
     context['create_event_url'] = '%s%s' % (
-        reverse('calendar_create_event', kwargs=lookup_context),
+        reverse('schedule:calendar_create_event', kwargs=lookup_context),
         querystring_for_date(slot))
     return context
 


### PR DESCRIPTION
## Summary
- namespace calendar event creation url lookups
- update templates to use the namespaced path

## Testing
- `pip install -r requirements.txt`
- `pytest schedule/tests -q` *(fails: OperationalError connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685a3fbbd97083328f47a938cdc61fae