### PR TITLE
Fix grammar for unauthorized page messages

### DIFF
--- a/schedule/templates/schedule/create_event.html
+++ b/schedule/templates/schedule/create_event.html
@@ -117,7 +117,7 @@
 </form>
 
 {% else %}
-Your not allowed to view this page..
+You're not allowed to view this page.
 {% endif %} 
 {% endblock %} 
 

--- a/schedule/templates/schedule/delete_event.html
+++ b/schedule/templates/schedule/delete_event.html
@@ -20,7 +20,7 @@
     </form>
   </div>
 {% else %}
-Your not allowed to view this page..
+You're not allowed to view this page.
 {% endif %} 
 {% endblock %} 
 

--- a/schedule/templates/schedule/event_form.html
+++ b/schedule/templates/schedule/event_form.html
@@ -118,7 +118,7 @@
 </form>
 
 {% else %}
-Your not allowed to view this page..
+You're not allowed to view this page.
 {% endif %} 
 {% endblock %} 
 

--- a/timecard/templates/timecard/timecard_confirm_delete.html
+++ b/timecard/templates/timecard/timecard_confirm_delete.html
@@ -24,6 +24,6 @@
   </div>
 </div>
 {% else %}
-Your not allowed to view this page..
+You're not allowed to view this page.
 {% endif %} 
 {% endblock %} 

--- a/timecard/templates/timecard/timecard_form2.html
+++ b/timecard/templates/timecard/timecard_form2.html
@@ -63,7 +63,7 @@
     </form>
 </div>
 {% else %}
-Your not allowed to view this page..
+You're not allowed to view this page.
 {% endif %}
 
 {% endblock %} 


### PR DESCRIPTION
## Summary
- fix typo in unauthorized page messages displayed in various templates

## Testing
- `pytest -q` *(fails: Model class helpdesk.models.base.Queue doesn't declare an explicit app_label and isn't in INSTALLED_APPS)*

------
https://chatgpt.com/codex/tasks/task_e_685a4161c18483328c8c885f14c213e4