### PR TITLE
Fix calendar list link in month view

### DIFF
--- a/schedule/templates/schedule/calendar_month.html
+++ b/schedule/templates/schedule/calendar_month.html
@@ -4,7 +4,7 @@
 
 {% block title %}Calendar Month{% endblock %}
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'calendar_list' %}">{{ calendar.name }}</a></li>
+<li class="breadcrumb-item"><a href="{% url 'schedule:calendar_list' %}">{{ calendar.name }}</a></li>
 {% endblock %}
 {% block styler %}  
   <link rel="stylesheet" href="{% static 'schedule/schedule.css' %}" type="text/css" media="screen">


### PR DESCRIPTION
## Summary
- update month calendar template breadcrumb to use schedule namespace

## Testing
- `bash codex_setup.sh`
- `pytest` *(fails: Model class helpdesk.models.base.Queue isn't in INSTALLED_APPS)*


------
https://chatgpt.com/codex/tasks/task_e_685a4330b9dc8332a1591ab47b75b0a8