### PR TITLE
Hide add client button for non-staff

### DIFF
--- a/client/templates/client/client_dashboard.html
+++ b/client/templates/client/client_dashboard.html
@@ -129,9 +129,11 @@ Client Management Dashboard - {{ request.user.company.company_name|default:"WBEE
                         <i class="fas fa-bolt me-2"></i>Quick Actions
                     </h5>
                     <div class="d-flex flex-wrap gap-2">
+                        {% if request.user.is_staff %}
                         <a href="{% url 'client:create' %}" class="btn btn-primary quick-action-btn">
                             <i class="fas fa-plus me-1"></i>Add Client
                         </a>
+                        {% endif %}
                         <a href="{% url 'client:list' %}?status=prospect" class="btn btn-warning quick-action-btn">
                             <i class="fas fa-search me-1"></i>View Prospects
                         </a>

--- a/client/templates/client/client_list.html
+++ b/client/templates/client/client_list.html
@@ -150,6 +150,7 @@ Client Directory - {{ request.user.company.company_name|default:"WBEE" }}
     justify-content: center;
     box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
     z-index: 1050;
+    font-size: 1.25rem;
   }
 </style>
 {% endblock %}
@@ -178,7 +179,7 @@ Client Directory - {{ request.user.company.company_name|default:"WBEE" }}
               <i class="fas fa-list"></i> Table
             </button>
           </div>
-          {% if request.user.staff %}
+          {% if request.user.is_staff %}
           <a href="{% url 'client:create' %}" class="btn btn-primary">
             <i class="fas fa-plus me-1"></i>Add Client
           </a>
@@ -529,9 +530,11 @@ Client Directory - {{ request.user.company.company_name|default:"WBEE" }}
     </div>
   </div>
 </div>
+{% if request.user.is_staff %}
 <a href="{% url 'client:create' %}" class="btn btn-primary rounded-circle add-client-btn" title="Add Client">
   <i class="fas fa-plus"></i>
 </a>
+{% endif %}
 {% endblock %}
 
 {% block scripter %}


### PR DESCRIPTION
## Summary
- only show the **Add Client** buttons when the user is a staff member
- make the floating Add Client button icon a little larger

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685a47352ba88332a0473e379f6fa5dc