### PR TITLE
Use dj_database_url by default; create .env for codex

### DIFF
--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 echo "Codex Setup Starting..."
 pip install -r requirements.txt
+
+# Create a minimal .env for local testing when one does not exist
+if [ ! -f .env ]; then
+    cat <<EOF > .env
+SECRET_KEY=dummysecret
+DEBUG=True
+DATABASE_URL=sqlite:///db.sqlite3
+EOF
+fi
+
+# Load environment variables and run migrations
 export $(grep -v '^#' .env | xargs)
 python manage.py migrate --noinput


### PR DESCRIPTION
## Summary
- revert automatic SQLite fallback so prod requires a `DATABASE_URL`
- generate a basic `.env` file in `codex_setup.sh` for local sqlite usage

## Testing
- `pip install -q -r requirements.txt`
- `pytest todo/tests/test_views.py::test_view_list -q` *(fails: Related model 'base.Queue' cannot be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_685a502a69dc8332a1a311027d23d47d