### PR TITLE
Secure env handling and codex setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-DJANGO_SETTINGS_MODULE=wbee.settings.base

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+DEBUG=True
+SECRET_KEY=your-secret-key
+ALLOWED_HOSTS=your-hosts
+DATABASE_URL=postgresql://USER:PASSWORD@HOST:PORT/DBNAME
+REDIS_URL=redis://localhost:6379/0
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_USE_TLS=True
+EMAIL_HOST_USER=your-email@example.com
+EMAIL_HOST_PASSWORD=your-password
+TIME_ZONE=America/Phoenix
+ENVIRONMENT=development

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ venv/
 env/
 ENV/
 *.env
+.env
 *.venv
 .Python
 

--- a/codex_setup.sh
+++ b/codex_setup.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
-set -e
-
-# Install dependencies
-python -m pip install -r requirements.txt
-
-# Ensure DJANGO_SETTINGS_MODULE is set
-export DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-wbee.settings.base}
-
-# Use SQLite database if DATABASE_URL is not provided
-export DATABASE_URL=${DATABASE_URL:-sqlite:///db.sqlite3}
-
-# Apply database migrations
+echo "Codex Setup Starting..."
+pip install -r requirements.txt
+export $(grep -v '^#' .env | xargs)
 python manage.py migrate --noinput
-
-# Collect static files (optional; uncomment if needed)
-# python manage.py collectstatic --noinput

--- a/wbee/settings/base.py
+++ b/wbee/settings/base.py
@@ -5,23 +5,24 @@ Production-ready configuration with environment variables
 
 import os
 from pathlib import Path
-from decouple import config, Csv
+from decouple import Csv, AutoConfig
 import dj_database_url
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
+config = AutoConfig(search_path=BASE_DIR)
 
 # ==============================================================================
 # CORE SETTINGS
 # ==============================================================================
 
 # Security
-SECRET_KEY = config('SECRET_KEY', default='a4$zmm5u_$ao70cmji80*8@8oedg&+mnm)r_a9p8@+znjmv8@w')
+SECRET_KEY = config('SECRET_KEY')
 DEBUG = config('DEBUG', default=True, cast=bool)
-ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='bb.wbee.app', cast=Csv())
+ALLOWED_HOSTS = config('ALLOWED_HOSTS', default='', cast=Csv())
 
 # Google Maps API key
-GOOGLE_MAPS_API_KEY = config('GOOGLE_MAPS_API_KEY', default='AIzaSyBC_8mf34uW13LKTM1fKekn_xL7w_socHE')
+GOOGLE_MAPS_API_KEY = config('GOOGLE_MAPS_API_KEY', default='')
 
 # Application definition
 DJANGO_APPS = [
@@ -56,7 +57,7 @@ LOCAL_APPS = [
     'client.apps.ClientConfig',
     'company.apps.CompanyConfig',  # New company management app
     'home.apps.HomeConfig',
-    #'helpdesk.apps.HelpdeskConfig',
+    'helpdesk.apps.HelpdeskConfig',
     'hr.apps.HrConfig',
     'location.apps.LocationConfig',
     'project.apps.ProjectConfig',
@@ -134,10 +135,20 @@ TEMPLATES = [
 #        'CONN_MAX_AGE': 600,
 #    }
 #}
-import dj_database_url
 DATABASES = {
-    'default': dj_database_url.config(default='postgres://workerbee:workerbee_secure_password_2025@localhost:5432/workerbee_db')
+    'default': dj_database_url.parse(
+        config('DATABASE_URL', default='')
+    )
 }
+
+import sys
+if 'pytest' in sys.argv[0]:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': ':memory:',
+        }
+    }
 
 # ==============================================================================
 # AUTHENTICATION


### PR DESCRIPTION
## Summary
- remove hardcoded secrets and read from environment
- switch to SQLite automatically when running pytest
- ignore `.env` and provide `.env.example`
- simplify codex setup script to load env vars
- ensure decouple searches project root for `.env`
- enable helpdesk app for tests
- fix database URL parsing so `.env` values load in production

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError in helpdesk tests)*

------
https://chatgpt.com/codex/tasks/task_e_685a466f6be0833283e37ed27b9e94f8