### PR TITLE
Fix calendar date parsing and event sorting

### DIFF
--- a/schedule/periods.py
+++ b/schedule/periods.py
@@ -94,7 +94,9 @@ class Period(object):
         for event in self.events:
             event_occurrences = event.get_occurrences(self.start, self.end, clear_prefetch=False)
             occurrences += event_occurrences
-        return sorted(occurrences, **self.sorting_options)
+        sort_opts = {'key': lambda o: o.start}
+        sort_opts.update(self.sorting_options)
+        return sorted(occurrences, **sort_opts)
 
     def cached_get_sorted_occurrences(self):
         if hasattr(self, '_occurrences'):

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -88,17 +88,17 @@ class MonthCalendarView(LoginRequiredMixin, DetailView):
     context_object_name = "calendar"
 
     def _get_date(self):
+        now = timezone.now()
         try:
-            parts = {
-                key: int(self.request.GET.get(key))
-                for key in ["year", "month", "day", "hour", "minute", "second"]
-                if self.request.GET.get(key) is not None
-            }
-            if parts:
-                return datetime.datetime(**parts)
+            year = int(self.request.GET.get("year", now.year))
+            month = int(self.request.GET.get("month", now.month))
+            day = int(self.request.GET.get("day", 1))
+            hour = int(self.request.GET.get("hour", 0))
+            minute = int(self.request.GET.get("minute", 0))
+            second = int(self.request.GET.get("second", 0))
+            return datetime.datetime(year, month, day, hour, minute, second)
         except ValueError:
             raise Http404
-        return timezone.now()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -127,17 +127,17 @@ class WeekCalendarView(LoginRequiredMixin, DetailView):
     context_object_name = "calendar"
 
     def _get_date(self):
+        now = timezone.now()
         try:
-            parts = {
-                key: int(self.request.GET.get(key))
-                for key in ["year", "month", "day", "hour", "minute", "second"]
-                if self.request.GET.get(key) is not None
-            }
-            if parts:
-                return datetime.datetime(**parts)
+            year = int(self.request.GET.get("year", now.year))
+            month = int(self.request.GET.get("month", now.month))
+            day = int(self.request.GET.get("day", now.day))
+            hour = int(self.request.GET.get("hour", 0))
+            minute = int(self.request.GET.get("minute", 0))
+            second = int(self.request.GET.get("second", 0))
+            return datetime.datetime(year, month, day, hour, minute, second)
         except ValueError:
             raise Http404
-        return timezone.now()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -166,17 +166,17 @@ class DayCalendarView(LoginRequiredMixin, DetailView):
     context_object_name = "calendar"
 
     def _get_date(self):
+        now = timezone.now()
         try:
-            parts = {
-                key: int(self.request.GET.get(key))
-                for key in ["year", "month", "day", "hour", "minute", "second"]
-                if self.request.GET.get(key) is not None
-            }
-            if parts:
-                return datetime.datetime(**parts)
+            year = int(self.request.GET.get("year", now.year))
+            month = int(self.request.GET.get("month", now.month))
+            day = int(self.request.GET.get("day", now.day))
+            hour = int(self.request.GET.get("hour", 0))
+            minute = int(self.request.GET.get("minute", 0))
+            second = int(self.request.GET.get("second", 0))
+            return datetime.datetime(year, month, day, hour, minute, second)
         except ValueError:
             raise Http404
-        return timezone.now()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -205,17 +205,17 @@ class YearCalendarView(LoginRequiredMixin, DetailView):
     context_object_name = "calendar"
 
     def _get_date(self):
+        now = timezone.now()
         try:
-            parts = {
-                key: int(self.request.GET.get(key))
-                for key in ["year", "month", "day", "hour", "minute", "second"]
-                if self.request.GET.get(key) is not None
-            }
-            if parts:
-                return datetime.datetime(**parts)
+            year = int(self.request.GET.get("year", now.year))
+            month = int(self.request.GET.get("month", 1))
+            day = int(self.request.GET.get("day", 1))
+            hour = int(self.request.GET.get("hour", 0))
+            minute = int(self.request.GET.get("minute", 0))
+            second = int(self.request.GET.get("second", 0))
+            return datetime.datetime(year, month, day, hour, minute, second)
         except ValueError:
             raise Http404
-        return timezone.now()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
## Summary
- ensure occurrences sort by start time
- handle missing query parameters when parsing dates for calendar views

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: Related model 'base.Queue' cannot be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_685a5acc88b08332b1832aba3bbcce76