### PR TITLE
Fix deprecated template tag

### DIFF
--- a/schedule/templates/schedule/_day_cell.html
+++ b/schedule/templates/schedule/_day_cell.html
@@ -1,5 +1,5 @@
 {% load scheduletags %}
-{% ifnotequal day.start.month month.start.month %}
+{% if day.start.month != month.start.month %}
   <td style="color:blue;" class="muted"></td>
 {% else %}
   {% if day.has_occurrences %}
@@ -13,8 +13,8 @@
     <strong>{{day.start.day}}</strong>
   </div>
   </a>
-  {% ifnotequal size "small" %}
+  {% if size != "small" %}
     {% include "schedule/_day_cell_big.html" %}
-  {% endifnotequal %}
+  {% endif %}
 </td>
-{% endifnotequal %}
+{% endif %}


### PR DESCRIPTION
## Summary
- fix deprecated `ifnotequal` template tag in `_day_cell.html`

## Testing
- `pytest -q` *(fails: SECRET_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5c9826cc8332a67654d050885637