### PR TITLE
Fix deprecated ifequal template tags

### DIFF
--- a/helpdesk/templates/helpdesk/debug.html
+++ b/helpdesk/templates/helpdesk/debug.html
@@ -3,9 +3,9 @@
             <h2>Queries</h2>
             <p>
                 {{ sql_queries|length }} Quer{{ sql_queries|pluralize:"y,ies" }}
-                {% ifnotequal sql_queries|length 0 %}
+                {% if sql_queries|length != 0 %}
                 (<span style="cursor: pointer;" onclick="var s=document.getElementById('debugQueryTable').style;s.display=s.display=='none'?'':'none';this.innerHTML=this.innerHTML=='Show'?'Hide':'Show';">Show</span>)
-                {% endifnotequal %}
+                {% endif %}
             </p>
             <table id="debugQueryTable" style="display: none;">
                 <col width="1"></col>

--- a/helpdesk/templates/helpdesk/kb_category.html
+++ b/helpdesk/templates/helpdesk/kb_category.html
@@ -12,7 +12,7 @@
 
 {% for item in items %}
 {% cycle 'one' 'two' 'three' as itemnumperrow silent %}
-{% ifequal itemnumperrow 'one' %}<div class="row">{% endifequal %}
+{% if itemnumperrow == 'one' %}<div class="row">{% endif %}
     <div class="col-lg-3">
         <div class="panel panel-primary">
             <div class="panel-heading">
@@ -32,7 +32,7 @@
             </div>
         </div>
     </div>
-{% ifequal itemnumperrow 'three' %}</div>{% endifequal %}
+{% if itemnumperrow == 'three' %}</div>{% endif %}
 {% endfor %}
 
 {% endblock %}

--- a/helpdesk/templates/helpdesk/navigation.html
+++ b/helpdesk/templates/helpdesk/navigation.html
@@ -40,7 +40,7 @@
                         {% for q in user_saved_queries_ %}
                             <li><a href="{% url 'helpdesk:list' %}?saved_query={{ q.id }}">{{ q.title }}
                                 {% if q.shared %}
-                                    (Shared{% ifnotequal user q.user %} by {{ q.user.get_username }}{% endifnotequal %})
+                                    (Shared{% if user != q.user %} by {{ q.user.get_username }}{% endif %})
                                 {% endif %}</a></li>
                         {% endfor %}
                     </ul>

--- a/helpdesk/templates/helpdesk/report_output.html
+++ b/helpdesk/templates/helpdesk/report_output.html
@@ -42,7 +42,7 @@
         <label for='saved_query'>{% trans "Select Query:" %}</label>
         <select name='saved_query'>
             <option value="">--------</option>{% for q in user_saved_queries_ %}
-            <option value="{{ q.id }}"{% ifequal saved_query q %} selected{% endifequal %}>{{ q.title }}</option>{% endfor %}
+            <option value="{{ q.id }}"{% if saved_query == q %} selected{% endif %}>{{ q.title }}</option>{% endfor %}
         </select>
         <input class="btn btn-primary" type='submit' value='{% trans "Filter Report" %}'>
     </form>

--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -155,39 +155,39 @@ $(document).on('change', ':file', function() {
 
         <dt><label>{% trans "New Status" %}</label></dt>
         {% if not ticket.can_be_resolved %}<dd>{% trans "This ticket cannot be resolved or closed until the tickets it depends on are resolved." %}</dd>{% endif %}
-        {% ifequal ticket.status 1 %}
+        {% if ticket.status == 1 %}
         <dd><div class="form-group">
             <label for='st_open' class='active radio-inline'><input type='radio' name='new_status' value='1' id='st_open' checked='checked'>{% trans "Open" %} &raquo;</label>
             <label for='st_resolved' class="radio-inline"><input type='radio' name='new_status' value='3' id='st_resolved'{% if not ticket.can_be_resolved %} disabled='disabled'{% endif %}>{% trans "Resolved" %} &raquo;</label>
             <label for='st_closed' class="radio-inline"><input type='radio' name='new_status' value='4' id='st_closed'{% if not ticket.can_be_resolved %} disabled='disabled'{% endif %}>{% trans "Closed" %} &raquo;</label>
             <label class="radio-inline" for='st_duplicate'><input type='radio' name='new_status' value='5' id='st_duplicate'>{% trans "Duplicate" %}</label>
         </div></dd>
-        {% endifequal %}
-        {% ifequal ticket.status 2 %}
+        {% endif %}
+        {% if ticket.status == 2 %}
         <dd><div class="form-group">
             <label for='st_reopened' class='active radio-inline'><input type='radio' name='new_status' value='2' id='st_reopened' checked='checked'>{% trans "Reopened" %} &raquo;</label>
             <label class="radio-inline" for='st_resolved'><input type='radio' name='new_status' value='3' id='st_resolved'{% if not ticket.can_be_resolved %} disabled='disabled'{% endif %}>{% trans "Resolved" %} &raquo;</label>
             <label class="radio-inline" for='st_closed'><input type='radio' name='new_status' value='4' id='st_closed'{% if not ticket.can_be_resolved %} disabled='disabled'{% endif %}>{% trans "Closed" %} &raquo;</label>
             <label class="radio-inline" for='st_duplicate'><input type='radio' name='new_status' value='5' id='st_duplicate'>{% trans "Duplicate" %}</label>
         </div></dd>
-        {% endifequal %}
-        {% ifequal ticket.status 3 %}
+        {% endif %}
+        {% if ticket.status == 3 %}
         <dd><div class="form-group">
             <label for='st_reopened' class="radio-inline"><input type='radio' name='new_status' value='2' id='st_reopened'>{% trans "Reopened" %} &laquo;</label>
             <label for='st_resolved' class='active radio-inline'><input type='radio' name='new_status' value='3' id='st_resolved' checked='checked'>{% trans "Resolved" %} &raquo;</label>
             <label class="radio-inline" for='st_closed'><input type='radio' name='new_status' value='4' id='st_closed'>{% trans "Closed" %}</label>
         </div></dd>
-        {% endifequal %}
-        {% ifequal ticket.status 4 %}
+        {% endif %}
+        {% if ticket.status == 4 %}
         <dd><div class="form-group"><label for='st_reopened' class="radio-inline"><input type='radio' name='new_status' value='2' id='st_reopened'>{% trans "Reopened" %} &laquo;</label>
         <label class="radio-inline" for='st_closed'><input type='radio' name='new_status' value='4' id='st_closed' checked='checked'>{% trans "Closed" %}</label></div></dd>
-        {% endifequal %}
-        {% ifequal ticket.status 5 %}
+        {% endif %}
+        {% if ticket.status == 5 %}
         <dd><div class="form-group">
             <label class="radio-inline" for='st_reopened'><input type='radio' name='new_status' value='2' id='st_reopened'>{% trans "Reopened" %} &laquo;</label>
             <label class="radio-inline" for='st_duplicate'><input type='radio' name='new_status' value='5' id='st_duplicate' checked='checked'>{% trans "Duplicate" %}</label>
         </div></dd>
-        {% endifequal %}
+        {% endif %}
 
         {% if helpdesk_settings.HELPDESK_UPDATE_PUBLIC_DEFAULT %}
         <input type='hidden' name='public' value='1'>
@@ -210,10 +210,10 @@ $(document).on('change', ':file', function() {
         <dd><input type='text' name='title' value='{{ ticket.title|escape }}' /></dd>
 
         <dt><label for='id_owner'>{% trans "Owner" %}</label></dt>
-        <dd><select id='id_owner' name='owner'><option value='0'>{% trans "Unassign" %}</option>{% for u in active_users %}<option value='{{ u.id }}' {% ifequal u.id ticket.assigned_to.id %}selected{% endifequal %}>{{ u }}</option>{% endfor %}</select></dd>
+        <dd><select id='id_owner' name='owner'><option value='0'>{% trans "Unassign" %}</option>{% for u in active_users %}<option value='{{ u.id }}' {% if u.id == ticket.assigned_to.id %}selected{% endif %}>{{ u }}</option>{% endfor %}</select></dd>
 
         <dt><label for='id_priority'>{% trans "Priority" %}</label></dt>
-        <dd><select id='id_priority' name='priority'>{% for p in priorities %}<option value='{{ p.0 }}'{% ifequal p.0 ticket.priority %} selected='selected'{% endifequal %}>{{ p.1 }}</option>{% endfor %}</select></dd>
+        <dd><select id='id_priority' name='priority'>{% for p in priorities %}<option value='{{ p.0 }}'{% if p.0 == ticket.priority %} selected='selected'{% endif %}>{{ p.1 }}</option>{% endfor %}</select></dd>
         
         <dt><label for='id_due_date'>{% trans "Due on" %}</label></dt>
         <dd>{{ form.due_date }}</dd>

--- a/helpdesk/templates/helpdesk/ticket_desc_table.html
+++ b/helpdesk/templates/helpdesk/ticket_desc_table.html
@@ -23,7 +23,7 @@
                                         {% for customfield in ticket.ticketcustomfieldvalue_set.all %}
                                         <tr>
                                             <th>{{ customfield.field.label }}</th>
-                                            <td>{% ifequal customfield.field.data_type "url" %}<a href='{{ customfield.value }}'>{{ customfield.value }}</a>{% else %}{{ customfield.value }}{% endifequal %}</td>
+                                            <td>{% if customfield.field.data_type == "url" %}<a href='{{ customfield.value }}'>{{ customfield.value }}</a>{% else %}{{ customfield.value }}{% endif %}</td>
                                         </tr>{% endfor %}
                                         <tr>
                                             <th colspan='2'>{% trans "Description" %}</th>
@@ -33,7 +33,7 @@
                                         </tr>
 
                                         {% if ticket.resolution %}<tr>
-                                            <th colspan='2'>{% trans "Resolution" %}{% ifequal ticket.get_status_display "Resolved" %} <a href='?close'><button type="button" class="btn btn-warning btn-xs">{% trans "Accept and Close" %}</button></a>{% endifequal %}</th>
+                                            <th colspan='2'>{% trans "Resolution" %}{% if ticket.get_status_display == "Resolved" %} <a href='?close'><button type="button" class="btn btn-warning btn-xs">{% trans "Accept and Close" %}</button></a>{% endif %}</th>
                                         </tr>
                                         <tr>
                                             <td colspan='2'>{{ ticket.resolution|force_escape|urlizetrunc:50|linebreaksbr }}</td>
@@ -50,7 +50,7 @@
 
                                         <tr>
                                             <th>{% trans "Assigned To" %}</th>
-                                            <td>{{ ticket.get_assigned_to }}{% ifequal ticket.get_assigned_to _('Unassigned') %} <strong><a href='?take'><button type="button" class="btn btn-primary btn-xs"><i class="fa fa-hand-paper-o"></i>&nbsp;{% trans "Take" %}</button></a></strong>{% endifequal %}</td>
+                                            <td>{{ ticket.get_assigned_to }}{% if ticket.get_assigned_to == _('Unassigned') %} <strong><a href='?take'><button type="button" class="btn btn-primary btn-xs"><i class="fa fa-hand-paper-o"></i>&nbsp;{% trans "Take" %}</button></a></strong>{% endif %}</td>
                                         </tr>
 
                                         <tr>

--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -72,22 +72,22 @@ $(document).ready(function() {
                                             <div class='thumbnail filterBox{% if query_params.sorting %} filterBoxShow{% endif %}' id='filterBoxSort'>
                                             <label for='id_sort'>{% trans "Sorting" %}</label>
                                             <select id='id_sort' name='sort'>
-                                                <option value='created'{% ifequal query_params.sorting "created"%} selected='selected'{% endifequal %}>
+                                                <option value='created'{% if query_params.sorting == "created" %} selected='selected'{% endif %}>
                                                     {% trans "Created" %}
                                                 </option>
-                                                <option value='title'{% ifequal query_params.sorting "title"%} selected='selected'{% endifequal %}>
+                                                <option value='title'{% if query_params.sorting == "title" %} selected='selected'{% endif %}>
                                                     {% trans "Title" %}
                                                 </option>
-                                                <option value='queue'{% ifequal query_params.sorting "queue"%} selected='selected'{% endifequal %}>
+                                                <option value='queue'{% if query_params.sorting == "queue" %} selected='selected'{% endif %}>
                                                     {% trans "Queue" %}
                                                 </option>
-                                                <option value='status'{% ifequal query_params.sorting "status"%} selected='selected'{% endifequal %}>
+                                                <option value='status'{% if query_params.sorting == "status" %} selected='selected'{% endif %}>
                                                     {% trans "Status" %}
                                                 </option>
-                                                <option value='priority'{% ifequal query_params.sorting "priority"%} selected='selected'{% endifequal %}>
+                                                <option value='priority'{% if query_params.sorting == "priority" %} selected='selected'{% endif %}>
                                                     {% trans "Priority" %}
                                                 </option>
-                                                <option value='assigned_to'{% ifequal query_params.sorting "assigned_to"%} selected='selected'{% endifequal %}>
+                                                <option value='assigned_to'{% if query_params.sorting == "assigned_to" %} selected='selected'{% endif %}>
                                                     {% trans "Owner" %}
                                                 </option>
                                             </select>
@@ -102,7 +102,7 @@ $(document).ready(function() {
                                             <select id='id_owners' name='assigned_to' multiple='selected' size='5'>
                                                 {% for u in user_choices %}
                                                 <option value='{{ u.id }}'{% if u.id|in_list:query_params.filtering.assigned_to__id__in %} selected='selected'{% endif %}>
-                                                    {{ u.get_username }}{% ifequal u user %} {% trans "(ME)" %}{% endifequal %}
+                                                    {{ u.get_username }}{% if u == user %} {% trans "(ME)" %}{% endif %}
                                                 </option>
                                                 {% endfor %}
                                             </select>
@@ -184,7 +184,7 @@ $(document).ready(function() {
                                             <form method='get' action='{% url 'helpdesk:list' %}'>
                                                 <p><label for='id_query_selector'>{% trans "Query" %}</label> <select name='saved_query' id='id_query_selector'>
                                                     {% for q in user_saved_queries %}
-                                                    <option value='{{ q.id }}'>{{ q.title }}{% if q.shared %} (Shared{% ifnotequal user q.user %} by {{ q.user.get_username }}{% endifnotequal %}){% endif %}</option>
+                                                    <option value='{{ q.id }}'>{{ q.title }}{% if q.shared %} (Shared{% if user != q.user %} by {{ q.user.get_username }}{% endif %}){% endif %}</option>
                                                     {% endfor %}
                                                 </select></p>
                                                 <input class="btn btn-primary" type='submit' value='{% trans "Run Query" %}'>

--- a/schedule/templates/profiles/schedule.html
+++ b/schedule/templates/profiles/schedule.html
@@ -35,14 +35,14 @@
                 <a href="{% url "event" event.pk %}" title="{% trans "Event details" %} {{ event }}">
                     <img src="{{ settings.MEDIA_URL }}icons/time_go.png" alt="{% trans "Event details" %}">
                 </a>
-                {% ifequal request.user other_user %}
+                {% if request.user == other_user %}
                 <a href="{% url "edit_event" calendar.slug event.pk %}" title="{% trans "Edit event" %} {{ event }}">
                     <img src="{{ settings.MEDIA_URL }}icons/time_edit.png" alt="{% trans "Edit event" %}">
                 </a>
                 <a href="{% url "delete_event" event.pk %}" title="{% trans "Delete event" %} {{ event }}">
                     <img src="{{ settings.MEDIA_URL }}icons/time_delete.png" alt="{% trans "Delete event" %}">
                 </a>
-                {% endifequal %}
+                {% endif %}
                 {% endblock schedule_event_controls %}
             </td>
         </tr>

--- a/schedule/templates/schedule/_day_cell_big copy.html
+++ b/schedule/templates/schedule/_day_cell_big copy.html
@@ -5,10 +5,10 @@
               <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#occurrenceModal">
 
                   <div class="starttime">
-                      {% ifequal o.class 0 %}{{ o.occurrence.start|time:"G:i" }}{% endifequal %}
-                      {% ifequal o.class 1 %}{{ o.occurrence.start|time:"G:i" }}{% endifequal %}
-                      {% ifequal o.class 2 %}(All day){% endifequal %}
-                      {% ifequal o.class 3 %}Ends at {{ o.occurrence.end|time:"G:i" }}{% endifequal %}
+                      {% if o.class == 0 %}{{ o.occurrence.start|time:"G:i" }}{% endif %}
+                      {% if o.class == 1 %}{{ o.occurrence.start|time:"G:i" }}{% endif %}
+                      {% if o.class == 2 %}(All day){% endif %}
+                      {% if o.class == 3 %}Ends at {{ o.occurrence.end|time:"G:i" }}{% endif %}
                   </div>
                   <div class="eventdesc">
                       {% title o.occurrence %}

--- a/schedule/templates/schedule/_day_cell_big.html
+++ b/schedule/templates/schedule/_day_cell_big.html
@@ -5,10 +5,10 @@
               <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="">
 
                   <div class="starttime">
-                      {% ifequal o.class 0 %}{{ o.occurrence.start|time:"G:i" }}{% endifequal %}
-                      {% ifequal o.class 1 %}{{ o.occurrence.start|time:"G:i" }}{% endifequal %}
-                      {% ifequal o.class 2 %}(All day){% endifequal %}
-                      {% ifequal o.class 3 %}Ends at {{ o.occurrence.end|time:"G:i" }}{% endifequal %}
+                      {% if o.class == 0 %}{{ o.occurrence.start|time:"G:i" }}{% endif %}
+                      {% if o.class == 1 %}{{ o.occurrence.start|time:"G:i" }}{% endif %}
+                      {% if o.class == 2 %}(All day){% endif %}
+                      {% if o.class == 3 %}Ends at {{ o.occurrence.end|time:"G:i" }}{% endif %}
                   </div>
                   <div class="eventdesc">
                       {% title o.occurrence %}


### PR DESCRIPTION
## Summary
- replace `ifequal`/`ifnotequal` usages with standard `if` comparisons in helpdesk and schedule templates

## Testing
- `pytest -q` *(fails: SECRET_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5d99574083329011a9936d056330