### PR TITLE
Disable incomplete helpdesk module

### DIFF
--- a/home/templates/home/base.html
+++ b/home/templates/home/base.html
@@ -34,9 +34,6 @@
                         <li class="nav-item">
                             <a class="nav-link" href="{% url 'home:index' %}">Dashboard</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="{% url 'helpdesk:home' %}">Help Desk</a>
-                        </li>
                     </ul>
                     <ul class="navbar-nav">
                         <li class="nav-item dropdown">

--- a/wbee/settings/base.py
+++ b/wbee/settings/base.py
@@ -57,7 +57,6 @@ LOCAL_APPS = [
     'client.apps.ClientConfig',
     'company.apps.CompanyConfig',  # New company management app
     'home.apps.HomeConfig',
-    'helpdesk.apps.HelpdeskConfig',
     'hr.apps.HrConfig',
     'location.apps.LocationConfig',
     'project.apps.ProjectConfig',

--- a/wbee/urls.py
+++ b/wbee/urls.py
@@ -23,7 +23,6 @@ urlpatterns = [
     path("client/", include("client.urls")),
     path("filer/", include("filer.urls")),
     path("hr/", include("hr.urls")),
-    path("helpdesk/", include("helpdesk.urls")),
     path("company/", include("company.urls")),
     path("location/", include("location.urls")),
     path('project/', include('project.urls')),


### PR DESCRIPTION
## Summary
- remove helpdesk app from `INSTALLED_APPS`
- drop helpdesk route from URLconf
- drop Help Desk menu link

## Testing
- `pip install -r requirements.txt -q`
- `pytest -q` *(fails: Model class helpdesk.models.base.Queue doesn't declare an explicit app_label)*

------
https://chatgpt.com/codex/tasks/task_e_685a60530d408332b76588e9b455b2a1