### PR TITLE
Add Help Desk app and homepage links

### DIFF
--- a/home/templates/home/home.html
+++ b/home/templates/home/home.html
@@ -284,6 +284,16 @@
             </div>
         </a>
     </div>
+    <div class="col">
+        <a href="{% url 'helpdesk:home' %}" class="text-decoration-none">
+            <div class="card text-center h-100">
+                <div class="card-body">
+                    <i class="fas fa-life-ring fa-2x mb-2 text-danger"></i>
+                    <div>Help Desk</div>
+                </div>
+            </div>
+        </a>
+    </div>
 </div>
 
 <!-- Quick Menu Dropdown for small screens -->
@@ -302,6 +312,7 @@
         <li><a class="dropdown-item" href="{% url 'todo:lists' %}"><i class="fas fa-tasks me-2 text-primary"></i>Todo</a></li>
         <li><a class="dropdown-item" href="{% url 'receipts:list' %}"><i class="fas fa-receipt me-2 text-secondary"></i>Receipts</a></li>
         <li><a class="dropdown-item" href="{% url 'wip:list' %}"><i class="fas fa-balance-scale me-2 text-warning"></i>WIP</a></li>
+        <li><a class="dropdown-item" href="{% url 'helpdesk:home' %}"><i class="fas fa-life-ring me-2 text-danger"></i>Help Desk</a></li>
     </ul>
 </div>
 

--- a/wbee/settings/base.py
+++ b/wbee/settings/base.py
@@ -64,6 +64,7 @@ LOCAL_APPS = [
     'material.apps.MaterialConfig',
     'schedule.apps.ScheduleConfig',
     'timecard.apps.TimecardConfig',
+    'helpdesk.apps.HelpdeskConfig',
     'todo',
     'wip.apps.WipConfig',
 ]


### PR DESCRIPTION
## Summary
- register helpdesk in `LOCAL_APPS`
- show a Help Desk card in dashboard quick menu
- add Help Desk to the mobile dropdown menu

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'six' from 'django.utils')*

------
https://chatgpt.com/codex/tasks/task_e_685a6419db48833284739281ce1b4430