### PR TITLE
Fix NoReverseMatch error for unsaved occurrences

### DIFF
--- a/schedule/urls.py
+++ b/schedule/urls.py
@@ -10,6 +10,16 @@ urlpatterns = [
     path("calendars/", views.CalendarListView.as_view(), name="calendar_list"),
     path("<int:calendar_id>/ical/", CalendarICalendar(), name="calendar-ical"),
     path("events/<int:pk>/", views.EventDetailView.as_view(), name="event-detail"),
+    path(
+        "occurrence/<int:pk>/",
+        views.OccurrenceDetailView.as_view(),
+        name="occurrence-detail",
+    ),
+    path(
+        "occurrence/by-date/<int:event_id>/<int:year>/<int:month>/<int:day>/<int:hour>/<int:minute>/<int:second>/",
+        views.occurrence_by_date,
+        name="occurrence-by-date",
+    ),
     path("event/create/<str:proj>/", views.EventCreateView.as_view(), name="create-event"),
     path(
         "calendars/<slug:slug>/create-event/",

--- a/schedule/views.py
+++ b/schedule/views.py
@@ -1,14 +1,14 @@
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.urls import reverse
 from django.views.generic import CreateView, DetailView, ListView
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, redirect
 from django.http import Http404
 from django.utils import timezone
 import datetime
 
 from .periods import Day, Week, Month, Year, weekday_names
 from .settings import GET_EVENTS_FUNC
-from .models import Event, Calendar
+from .models import Event, Calendar, Occurrence
 from .forms import NewEventForm
 from project.models import Project
 
@@ -238,4 +238,22 @@ class TriMonthCalendarView(MonthCalendarView):
     """Display a three-month calendar view for a specific calendar."""
 
     template_name = "schedule/calendar_tri_month.html"
+
+
+class OccurrenceDetailView(LoginRequiredMixin, DetailView):
+    """Simple detail view for a persisted occurrence."""
+
+    model = Occurrence
+    template_name = "schedule/occurrence.html"
+    context_object_name = "occurrence"
+
+
+def occurrence_by_date(request, event_id, year, month, day, hour, minute, second):
+    """Fallback view for unsaved occurrences.
+
+    Since individual occurrence views are not supported, redirect the
+    request to the associated event detail page.
+    """
+
+    return redirect("schedule:event-detail", event_id)
 


### PR DESCRIPTION
## Summary
- add simple occurrence detail and by-date views
- expose the new views in `schedule/urls.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Model class helpdesk.models.base.Queue doesn't declare an explicit app_label)*

------
https://chatgpt.com/codex/tasks/task_e_685a648bea708332ba4b88badb569ad3