### PR TITLE
Fix NoReverseMatch for helpdesk home link

### DIFF
--- a/helpdesk/tests/urls.py
+++ b/helpdesk/tests/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^helpdesk/', include('helpdesk.urls', namespace='helpdesk')),
-    url(r'^admin/', admin.site.urls),
+    path('helpdesk/', include('helpdesk.urls', namespace='helpdesk')),
+    path('admin/', admin.site.urls),
 ]

--- a/helpdesk/urls.py
+++ b/helpdesk/urls.py
@@ -7,7 +7,7 @@ urls.py - Mapping of URL's to our various views. Note we always used NAMED
           views for simplicity in linking later on.
 """
 
-from django.conf.urls import url
+from django.urls import path, re_path
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import views as auth_views
 from django.views.generic import TemplateView
@@ -33,174 +33,174 @@ class DirectTemplateView(TemplateView):
 app_name = 'helpdesk'
 
 urlpatterns = [
-    url(r'^dashboard/$',
+    re_path(r'^dashboard/$',
         staff.dashboard,
         name='dashboard'),
 
-    url(r'^tickets/$',
+    re_path(r'^tickets/$',
         staff.ticket_list,
         name='list'),
 
-    url(r'^tickets/update/$',
+    re_path(r'^tickets/update/$',
         staff.mass_update,
         name='mass_update'),
 
-    url(r'^tickets/submit/$',
+    re_path(r'^tickets/submit/$',
         staff.create_ticket,
         name='submit'),
 
-    url(r'^tickets/(?P<ticket_id>[0-9]+)/$',
+    re_path(r'^tickets/(?P<ticket_id>[0-9]+)/$',
         staff.view_ticket,
         name='view'),
 
-    url(r'^tickets/(?P<ticket_id>[0-9]+)/followup_edit/(?P<followup_id>[0-9]+)/$',
+    re_path(r'^tickets/(?P<ticket_id>[0-9]+)/followup_edit/(?P<followup_id>[0-9]+)/$',
         staff.followup_edit,
         name='followup_edit'),
 
-    url(r'^tickets/(?P<ticket_id>[0-9]+)/followup_delete/(?P<followup_id>[0-9]+)/$',
+    re_path(r'^tickets/(?P<ticket_id>[0-9]+)/followup_delete/(?P<followup_id>[0-9]+)/$',
         staff.followup_delete,
         name='followup_delete'),
 
-    url(r'^tickets/(?P<ticket_id>[0-9]+)/edit/$',
+    re_path(r'^tickets/(?P<ticket_id>[0-9]+)/edit/$',
         staff.edit_ticket,
         name='edit'),
 
-    url(r'^tickets/(?P<ticket_id>[0-9]+)/update/$',
+    re_path(r'^tickets/(?P<ticket_id>[0-9]+)/update/$',
         staff.update_ticket,
         name='update'),
 
-    url(r'^tickets/(?P<ticket_id>[0-9]+)/delete/$',
+    re_path(r'^tickets/(?P<ticket_id>[0-9]+)/delete/$',
         staff.delete_ticket,
         name='delete'),
 
-    url(r'^tickets/(?P<ticket_id>[0-9]+)/hold/$',
+    re_path(r'^tickets/(?P<ticket_id>[0-9]+)/hold/$',
         staff.hold_ticket,
         name='hold'),
 
-    url(r'^tickets/(?P<ticket_id>[0-9]+)/unhold/$',
+    re_path(r'^tickets/(?P<ticket_id>[0-9]+)/unhold/$',
         staff.unhold_ticket,
         name='unhold'),
 
-    url(r'^tickets/(?P<ticket_id>[0-9]+)/cc/$',
+    re_path(r'^tickets/(?P<ticket_id>[0-9]+)/cc/$',
         staff.ticket_cc,
         name='ticket_cc'),
 
-    url(r'^tickets/(?P<ticket_id>[0-9]+)/cc/add/$',
+    re_path(r'^tickets/(?P<ticket_id>[0-9]+)/cc/add/$',
         staff.ticket_cc_add,
         name='ticket_cc_add'),
 
-    url(r'^tickets/(?P<ticket_id>[0-9]+)/cc/delete/(?P<cc_id>[0-9]+)/$',
+    re_path(r'^tickets/(?P<ticket_id>[0-9]+)/cc/delete/(?P<cc_id>[0-9]+)/$',
         staff.ticket_cc_del,
         name='ticket_cc_del'),
 
-    url(r'^tickets/(?P<ticket_id>[0-9]+)/dependency/add/$',
+    re_path(r'^tickets/(?P<ticket_id>[0-9]+)/dependency/add/$',
         staff.ticket_dependency_add,
         name='ticket_dependency_add'),
 
-    url(r'^tickets/(?P<ticket_id>[0-9]+)/dependency/delete/(?P<dependency_id>[0-9]+)/$',
+    re_path(r'^tickets/(?P<ticket_id>[0-9]+)/dependency/delete/(?P<dependency_id>[0-9]+)/$',
         staff.ticket_dependency_del,
         name='ticket_dependency_del'),
 
-    url(r'^tickets/(?P<ticket_id>[0-9]+)/attachment_delete/(?P<attachment_id>[0-9]+)/$',
+    re_path(r'^tickets/(?P<ticket_id>[0-9]+)/attachment_delete/(?P<attachment_id>[0-9]+)/$',
         staff.attachment_del,
         name='attachment_del'),
 
-    url(r'^raw/(?P<type>\w+)/$',
+    re_path(r'^raw/(?P<type>\w+)/$',
         staff.raw_details,
         name='raw'),
 
-    url(r'^rss/$',
+    re_path(r'^rss/$',
         staff.rss_list,
         name='rss_index'),
 
-    url(r'^reports/$',
+    re_path(r'^reports/$',
         staff.report_index,
         name='report_index'),
 
-    url(r'^reports/(?P<report>\w+)/$',
+    re_path(r'^reports/(?P<report>\w+)/$',
         staff.run_report,
         name='run_report'),
 
-    url(r'^save_query/$',
+    re_path(r'^save_query/$',
         staff.save_query,
         name='savequery'),
 
-    url(r'^delete_query/(?P<id>[0-9]+)/$',
+    re_path(r'^delete_query/(?P<id>[0-9]+)/$',
         staff.delete_saved_query,
         name='delete_query'),
 
-    url(r'^settings/$',
+    re_path(r'^settings/$',
         staff.user_settings,
         name='user_settings'),
 
-    url(r'^ignore/$',
+    re_path(r'^ignore/$',
         staff.email_ignore,
         name='email_ignore'),
 
-    url(r'^ignore/add/$',
+    re_path(r'^ignore/add/$',
         staff.email_ignore_add,
         name='email_ignore_add'),
 
-    url(r'^ignore/delete/(?P<id>[0-9]+)/$',
+    re_path(r'^ignore/delete/(?P<id>[0-9]+)/$',
         staff.email_ignore_del,
         name='email_ignore_del'),
 ]
 
 urlpatterns += [
-    url(r'^$',
+    path('',
         public.homepage,
         name='home'),
 
-    url(r'^view/$',
+    path('view/',
         public.view_ticket,
         name='public_view'),
 
-    url(r'^change_language/$',
+    path('change_language/',
         public.change_language,
         name='public_change_language'),
 ]
 
 urlpatterns += [
-    url(r'^rss/user/(?P<user_name>[^/]+)/$',
+    re_path(r'^rss/user/(?P<user_name>[^/]+)/$',
         login_required(feeds.OpenTicketsByUser()),
         name='rss_user'),
 
-    url(r'^rss/user/(?P<user_name>[^/]+)/(?P<queue_slug>[A-Za-z0-9_-]+)/$',
+    re_path(r'^rss/user/(?P<user_name>[^/]+)/(?P<queue_slug>[A-Za-z0-9_-]+)/$',
         login_required(feeds.OpenTicketsByUser()),
         name='rss_user_queue'),
 
-    url(r'^rss/queue/(?P<queue_slug>[A-Za-z0-9_-]+)/$',
+    re_path(r'^rss/queue/(?P<queue_slug>[A-Za-z0-9_-]+)/$',
         login_required(feeds.OpenTicketsByQueue()),
         name='rss_queue'),
 
-    url(r'^rss/unassigned/$',
+    re_path(r'^rss/unassigned/$',
         login_required(feeds.UnassignedTickets()),
         name='rss_unassigned'),
 
-    url(r'^rss/recent_activity/$',
+    re_path(r'^rss/recent_activity/$',
         login_required(feeds.RecentFollowUps()),
         name='rss_activity'),
 ]
 
 
 urlpatterns += [
-    url(r'^login/$',
+    re_path(r'^login/$',
         login.login,
         name='login'),
 
-    url(r'^logout/$',
+    re_path(r'^logout/$',
         auth_views.LogoutView.as_view(
             template_name='helpdesk/registration/login.html',
             next_page='../'),
         name='logout'),
 
-    url(r'^password_change/$',
+    re_path(r'^password_change/$',
         auth_views.PasswordChangeView.as_view(
             template_name='helpdesk/registration/change_password.html',
             success_url='./done'),
         name='password_change'),
 
-    url(r'^password_change/done$',
+    re_path(r'^password_change/done$',
         auth_views.PasswordChangeDoneView.as_view(
             template_name='helpdesk/registration/change_password_done.html',),
         name='password_change_done'),
@@ -208,29 +208,29 @@ urlpatterns += [
 
 if helpdesk_settings.HELPDESK_KB_ENABLED:
     urlpatterns += [
-        url(r'^kb/$',
+        re_path(r'^kb/$',
             kb.index,
             name='kb_index'),
 
-        url(r'^kb/(?P<item>[0-9]+)/$',
+        re_path(r'^kb/(?P<item>[0-9]+)/$',
             kb.item,
             name='kb_item'),
 
-        url(r'^kb/(?P<item>[0-9]+)/vote/$',
+        re_path(r'^kb/(?P<item>[0-9]+)/vote/$',
             kb.vote,
             name='kb_vote'),
 
-        url(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/$',
+        re_path(r'^kb/(?P<slug>[A-Za-z0-9_-]+)/$',
             kb.category,
             name='kb_category'),
     ]
 
 urlpatterns += [
-    url(r'^help/context/$',
+    re_path(r'^help/context/$',
         TemplateView.as_view(template_name='helpdesk/help_context.html'),
         name='help_context'),
 
-    url(r'^system_settings/$',
+    re_path(r'^system_settings/$',
         DirectTemplateView.as_view(template_name='helpdesk/system_settings.html'),
         name='system_settings'),
 ]


### PR DESCRIPTION
## Summary
- modernize helpdesk URL configuration by using `path`/`re_path`
- update tests URL config accordingly

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: SECRET_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a68518d3083328c53ff21c40c90c3