### PR TITLE
Fix ugettext import error

### DIFF
--- a/helpdesk/management/commands/create_usersettings.py
+++ b/helpdesk/management/commands/create_usersettings.py
@@ -8,7 +8,7 @@ create_usersettings.py - Easy way to create helpdesk-specific settings for
 users who don't yet have them.
 """
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.core.management.base import BaseCommand
 from django.contrib.auth import get_user_model
 

--- a/helpdesk/management/commands/escalate_tickets.py
+++ b/helpdesk/management/commands/escalate_tickets.py
@@ -16,7 +16,7 @@ import sys
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db.models import Q
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 try:
     from django.utils import timezone

--- a/helpdesk/management/commands/get_email.py
+++ b/helpdesk/management/commands/get_email.py
@@ -37,7 +37,7 @@ from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management.base import BaseCommand
 from django.db.models import Q
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils import encoding, six, timezone
 
 from helpdesk import settings

--- a/helpdesk/views/feeds.py
+++ b/helpdesk/views/feeds.py
@@ -11,7 +11,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.syndication.views import Feed
 from django.urls import reverse
 from django.db.models import Q
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.shortcuts import get_object_or_404
 
 from helpdesk.models import Ticket, FollowUp, Queue

--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -16,7 +16,7 @@ except ImportError:
 from django.http import HttpResponseRedirect, HttpResponse
 from django.shortcuts import render
 from django.utils.http import urlquote
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.conf import settings
 
 from helpdesk import settings as helpdesk_settings

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -19,7 +19,7 @@ from django.db.models import Q
 from django.http import HttpResponseRedirect, Http404, HttpResponse
 from django.shortcuts import render, get_object_or_404
 from django.utils.dates import MONTHS_3
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils.html import escape
 from django import forms
 from django.utils import timezone


### PR DESCRIPTION
## Summary
- replace deprecated `ugettext` import with `gettext`

## Testing
- `pytest -q` *(fails: SECRET_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a69c951808332a65618013a10001a