### PR TITLE
Fix import error for urlquote

### DIFF
--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -15,7 +15,7 @@ except ImportError:
     from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, HttpResponse
 from django.shortcuts import render
-from django.utils.http import urlquote
+from urllib.parse import quote
 from django.utils.translation import gettext as _
 from django.conf import settings
 
@@ -54,7 +54,7 @@ def homepage(request):
                     return HttpResponseRedirect('%s?ticket=%s&email=%s' % (
                         reverse('helpdesk:public_view'),
                         ticket.ticket_for_url,
-                        urlquote(ticket.submitter_email))
+                        quote(ticket.submitter_email))
                     )
                 except ValueError:
                     # if someone enters a non-int string for the ticket


### PR DESCRIPTION
## Summary
- use Python's `quote` function instead of `django.utils.http.urlquote`

## Testing
- `SECRET_KEY=abc DATABASE_URL=sqlite:///:memory: pytest -q` *(fails: TemplateSyntaxError: 'bootstrap' is not a registered tag library)*

------
https://chatgpt.com/codex/tasks/task_e_685a6c86120c8332bf801a0486ca2751