### PR TITLE
Fix phone number validation

### DIFF
--- a/client/models.py
+++ b/client/models.py
@@ -82,8 +82,8 @@ class Contact(TimeStampedModel):
     
     # Phone with validation
     phone_regex = RegexValidator(
-        regex=r'^\+?1?\d{9,15}$',
-        message="Phone number must be entered in the format: '+999999999'. Up to 15 digits allowed."
+        regex=r'^\+?[\d\s().-]{7,20}$',
+        message="Enter a valid phone number."
     )
     phone = models.CharField(validators=[phone_regex], max_length=17, blank=True)
     email = models.EmailField(blank=True)


### PR DESCRIPTION
## Summary
- allow common phone number formatting in Contact phone regex

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_685b641ad03c83328624c2388e49a3f1