### PR TITLE
Fix BusinessConfiguration admin slug error

### DIFF
--- a/business/admin.py
+++ b/business/admin.py
@@ -38,10 +38,6 @@ class BusinessConfigurationAdmin(admin.ModelAdmin):
         'updated_at',
     )
 
-    prepopulated_fields = {
-        'slug': ('name',),
-    }
-
     fieldsets = (
         ('General', {
             'fields': (


### PR DESCRIPTION
## Summary
- remove `prepopulated_fields` entry for the `slug` field so the admin form no longer errors

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: No module named 'decouple')*

------
https://chatgpt.com/codex/tasks/task_e_685caf5a46088332a4338a0365766af6