### PR TITLE
Fix theme admin readability

### DIFF
--- a/static/admin/css/modern-admin.css
+++ b/static/admin/css/modern-admin.css
@@ -33,3 +33,13 @@ button, input[type="submit"] {
 button:hover, input[type="submit"]:hover {
     background-color: #2563eb;
 }
+
+/* Improve readability of the admin theme configuration page */
+.admin-interface .module caption {
+    background-color: #f0f0f0;
+    color: #111;
+}
+
+.admin-interface .module h2 {
+    color: #0f172a;
+}


### PR DESCRIPTION
## Summary
- tweak CSS to improve readability of the admin theme configuration page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685cbf6ebf8c8332b10ab5e535ae815a