### PR TITLE
Fix project field names in schedule templates

### DIFF
--- a/schedule/templates/schedule/_detail.html
+++ b/schedule/templates/schedule/_detail.html
@@ -14,7 +14,7 @@
             {% if occurrence.event.project %}
             <tr>
                 <td class="left">Project</td>
-                <td><a style="color:black;font-weight:bold;" href="{{ occurrence.event.project.get_absolute_url }}">{{occurrence.event.project.job_name}}</a></td>
+                <td><a style="color:black;font-weight:bold;" href="{{ occurrence.event.project.get_absolute_url }}">{{occurrence.event.project.name}}</a></td>
             </tr>
             {% endif %}
             {% if occurrence.event.start_time %}

--- a/schedule/templates/schedule/dayevent_detail.html
+++ b/schedule/templates/schedule/dayevent_detail.html
@@ -39,7 +39,7 @@
         </h5>
         
         <h4>
-          <a href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.job_name }} : {{ dayevent.project.job_num }}</a>
+          <a href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.name }} : {{ dayevent.project.job_number }}</a>
         </h4>
         <p class="
           {% if dayevent.project.status == 'p' %}statusProspect

--- a/schedule/templates/schedule/event.html
+++ b/schedule/templates/schedule/event.html
@@ -32,7 +32,7 @@
         <div class="row">
           <div class="col-lg-6">
             <h4>
-              <a href="{{ event.project.get_absolute_url }}">{{ event.project.job_name }} : {{ event.project.job_num }}</a>
+              <a href="{{ event.project.get_absolute_url }}">{{ event.project.name }} : {{ event.project.job_number }}</a>
             </h4>
             <p class="
               {% if event.project.status == 'p' %}statusProspect

--- a/schedule/templates/schedule/event_archive_day.html
+++ b/schedule/templates/schedule/event_archive_day.html
@@ -59,9 +59,9 @@
             <td style="min-width:80px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ workers.get_absolute_url }}">{{ workers.first_name }} {{ workers.last_name }}</a><br> </td>
             <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ event.get_absolute_url }}">{{ event.start_time|date:'f A' }}</a> </td>
             <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ event.get_absolute_url }}">{{ event.start|date:'f A' }}</a> </td>
-            <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ event.project.get_absolute_url }}">{{ event.project.job_name|truncatechars:48 }}</a> </td>
+            <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ event.project.get_absolute_url }}">{{ event.project.name|truncatechars:48 }}</a> </td>
             <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ event.project.jobsite.google_maps_link }}">{{ event.project.jobsite.street_address }}, {{ event.project.jobsite.city }}, {{ event.project.jobsite.state }}, {{ event.project.jobsite.zipcode }}</a></td>
-            <td style="min-width:64px;font-weight:bold;"><a style="color:black;" href="{{ event.project.get_absolute_url }}">{{ event.project.job_num }}</a> </td>
+            <td style="min-width:64px;font-weight:bold;"><a style="color:black;" href="{{ event.project.get_absolute_url }}">{{ event.project.job_number }}</a> </td>
           </tr>
         {% if not forloop.last %} {% endif %}
         {% endfor %}

--- a/schedule/templates/schedule/schedule_day_list.html
+++ b/schedule/templates/schedule/schedule_day_list.html
@@ -6,7 +6,7 @@
 <li class="breadcrumb-item"><a href="{% url 'schedule:schedule' %}">Schedule</a></li>
 <li class="breadcrumb-item active"><b>{{ now|date:"F, jS o" }}</b></li>
 {% if request.user.staff %}
-<li class="breadcrumb-item"><a href="{% url 'create-event' proj=dayevent.project.job_num %}">add a new event</a></li>
+<li class="breadcrumb-item"><a href="{% url 'create-event' proj=dayevent.project.job_number %}">add a new event</a></li>
 {% endif %}
 {% endblock %}
 
@@ -55,9 +55,9 @@
             <td style="min-width:80px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ workers.get_absolute_url }}">{{ workers.first_name }} {{ workers.last_name }}</a><br> </td>
             <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">{{ dayevent.start_time|date:"f A" }}</a> </td>
             <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">{{ dayevent.start|date:"f A" }}</a> </td>
-            <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.job_name|truncatechars:48 }}</a> </td>
+            <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.name|truncatechars:48 }}</a> </td>
             <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.jobsite.google_maps_link }}">{{ dayevent.project.jobsite.street_address }}, {{ dayevent.project.jobsite.city }}, {{ dayevent.project.jobsite.state }}, {{ dayevent.project.jobsite.zipcode }}</a></td>
-            <td style="min-width:64px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.job_num }}</a> </td>
+            <td style="min-width:64px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.job_number }}</a> </td>
           </tr>
         {% if not forloop.last %} {% endif %}
         {% endfor %}
@@ -72,9 +72,9 @@
           <td style="min-width:80px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ workers.get_absolute_url }}">{{ workers.first_name }} {{ workers.last_name }}</a><br> </td>
           <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">{{ dayevent.start_time|date:"f A" }}</a> </td>
           <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">{{ dayevent.start|date:"f A" }}</a> </td>
-          <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.job_name|truncatechars:48 }}</a> </td>
+          <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.name|truncatechars:48 }}</a> </td>
           <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.jobsite.google_maps_link }}">{{ dayevent.project.jobsite.street_address }}, {{ dayevent.project.jobsite.city }}, {{ dayevent.project.jobsite.state }}, {{ dayevent.project.jobsite.zipcode }}</a></td>
-          <td style="min-width:64px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.job_num }}</a> </td>
+          <td style="min-width:64px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.job_number }}</a> </td>
           </tr>
         {% if not forloop.last %} {% endif %}
         {% endfor %}

--- a/todo/forms.py
+++ b/todo/forms.py
@@ -22,7 +22,7 @@ class AddTaskListForm(ModelForm):
         }
 
         if proj:
-            self.fields["scope"].queryset = ScopeOfWork.objects.filter(project__job_num=proj)
+            self.fields["scope"].queryset = ScopeOfWork.objects.filter(project__job_number=proj)
         else:
             self.fields["scope"].queryset = ScopeOfWork.objects.all()
         self.fields["scope"].widget.attrs = {


### PR DESCRIPTION
## Summary
- use `job_number` and `name` fields when rendering project data
- update todo forms to filter by `project__job_number`

## Testing
- `pip install -r requirements.txt` *(fails: some tests error)*
- `pytest -q` *(fails: bootstrap tag errors and DB settings)*

------
https://chatgpt.com/codex/tasks/task_e_685cc3e39bd8833285471b952e0573e2