### PR TITLE
Fix location create page

### DIFF
--- a/location/templates/location/location_form.html
+++ b/location/templates/location/location_form.html
@@ -20,9 +20,29 @@
 {% endblock %}
 
 {% block content %}
-<form method="post" enctype="multipart/form-data" class="mb-3">
-  {% csrf_token %}
-  {{ form.as_p }}
-  <button type="submit" class="btn btn-primary">Save</button>
-</form>
+<div class="container">
+  <h1 class="mb-4">{% if form.instance.pk %}Edit {{ form.instance.name }}{% else %}Add New Location{% endif %}</h1>
+
+  {% if form.errors %}
+  <div class="alert alert-danger">Please correct the errors below.</div>
+  {% endif %}
+
+  <form method="post" enctype="multipart/form-data" novalidate>
+    {% csrf_token %}
+    {% for field in form.visible_fields %}
+      <div class="mb-3">
+        {{ field.label_tag }}
+        {{ field }}
+        {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
+        {% if field.errors %}<div class="invalid-feedback d-block">{{ field.errors|first }}</div>{% endif %}
+        {% if field.name == 'location_type' %}
+          <div class="form-text">
+            <a href="{% url 'admin:location_locationtype_add' %}" target="_blank">Add Location Type</a>
+          </div>
+        {% endif %}
+      </div>
+    {% endfor %}
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
 {% endblock %}

--- a/location/views.py
+++ b/location/views.py
@@ -203,12 +203,12 @@ class LocationDetailView(DetailView):
         return context
 
 
-class LocationCreateView(LoginRequiredMixin, CreateView):
+class LocationCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
     """Create new location"""
     model = Location
     form_class = LocationForm
     template_name = 'location/location_form.html'
-    
+
     def form_valid(self, form):
         messages.success(self.request, f'Location "{form.instance.name}" created successfully!')
         return super().form_valid(form)
@@ -220,6 +220,16 @@ class LocationCreateView(LoginRequiredMixin, CreateView):
         if client_id:
             initial['client'] = client_id
         return initial
+
+    def test_func(self):
+        return self.request.user.is_staff
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        form = context.get('form')
+        if form:
+            context['location_type_count'] = form.fields['location_type'].queryset.count()
+        return context
 
 
 class LocationUpdateView(LoginRequiredMixin, UpdateView):
@@ -280,7 +290,7 @@ def get_dynamic_choices(request):
 
 
 # Document management views
-class LocationDocumentCreateView(LoginRequiredMixin, CreateView):
+class LocationDocumentCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
     """Add document to location"""
     model = LocationDocument
     form_class = LocationDocumentForm
@@ -295,6 +305,9 @@ class LocationDocumentCreateView(LoginRequiredMixin, CreateView):
     def get_success_url(self):
         return reverse('location:location-detail', kwargs={'pk': self.kwargs['location_pk']})
 
+    def test_func(self):
+        return self.request.user.is_staff
+
 
 class LocationDocumentDeleteView(LoginRequiredMixin, DeleteView):
     """Delete location document"""
@@ -306,7 +319,7 @@ class LocationDocumentDeleteView(LoginRequiredMixin, DeleteView):
 
 
 # Note management views
-class LocationNoteCreateView(LoginRequiredMixin, CreateView):
+class LocationNoteCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
     """Add note to location"""
     model = LocationNote
     form_class = LocationNoteForm
@@ -320,6 +333,9 @@ class LocationNoteCreateView(LoginRequiredMixin, CreateView):
     
     def get_success_url(self):
         return reverse('location:location-detail', kwargs={'pk': self.kwargs['location_pk']})
+
+    def test_func(self):
+        return self.request.user.is_staff
 
 
 class LocationNoteUpdateView(LoginRequiredMixin, UpdateView):


### PR DESCRIPTION
## Summary
- restrict location create/document/note views to staff
- add context about missing location types
- display field errors and link to create location types

## Testing
- `pytest -q` *(fails: SECRET_KEY and DB config missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ce7c89fd483329ec83d3e34bea049