### PR TITLE
Fix empty dropdowns on location creation

### DIFF
--- a/location/templates/location/location_form.html
+++ b/location/templates/location/location_form.html
@@ -39,10 +39,26 @@
           <div class="form-text">
             <a href="{% url 'admin:location_locationtype_add' %}" target="_blank">Add Location Type</a>
           </div>
+        {% elif field.name == 'status' %}
+          <div class="form-text">
+            <a href="{% url 'admin:location_configurablechoice_add' %}?choice_type=location_status" target="_blank">Add Status</a>
+          </div>
+        {% elif field.name == 'access_requirements' %}
+          <div class="form-text">
+            <a href="{% url 'admin:location_configurablechoice_add' %}?choice_type=access_requirement" target="_blank">Add Access Requirement</a>
+          </div>
+        {% elif field.name == 'work_hours' %}
+          <div class="form-text">
+            <a href="{% url 'admin:location_configurablechoice_add' %}?choice_type=work_hours" target="_blank">Add Work Hours Option</a>
+          </div>
         {% endif %}
       </div>
     {% endfor %}
     <button type="submit" class="btn btn-primary">Save</button>
   </form>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script src="{% static 'location/js/location_form.js' %}"></script>
 {% endblock %}

--- a/static/location/js/location_form.js
+++ b/static/location/js/location_form.js
@@ -1,0 +1,36 @@
+// JavaScript to dynamically populate Location form dropdowns
+function updateChoices(catId) {
+    const endpoints = {
+        location_type: `/location/ajax/location-types/?business_category=${catId}`,
+        status: `/location/ajax/dynamic-choices/?business_category=${catId}&choice_type=location_status`,
+        access_requirements: `/location/ajax/dynamic-choices/?business_category=${catId}&choice_type=access_requirement`,
+        work_hours: `/location/ajax/dynamic-choices/?business_category=${catId}&choice_type=work_hours`
+    };
+
+    for (const [field, url] of Object.entries(endpoints)) {
+        fetch(url)
+            .then(r => r.json())
+            .then(data => {
+                const select = document.getElementById(`id_${field}`);
+                if (!select) return;
+                select.innerHTML = '';
+                const choices = data[field + 's'] || data.choices || [];
+                choices.forEach(c => {
+                    const opt = document.createElement('option');
+                    opt.value = c.id || c[0] || c.value;
+                    opt.textContent = c.name || c[1] || c.display_name || c.text || c;
+                    select.appendChild(opt);
+                });
+            });
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const bc = document.getElementById('id_business_category');
+    if (!bc) return;
+    bc.addEventListener('change', e => {
+        const val = e.target.value;
+        if (val) updateChoices(val);
+    });
+    if (bc.value) updateChoices(bc.value);
+});


### PR DESCRIPTION
## Summary
- add dynamic dropdown loading script for the Location form
- add 'Add' links for status, access requirement, and work hours options
- include script in the template

## Testing
- `pytest -q` *(fails: SECRET_KEY not found / numerous errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d00dfaba883328e976cd75a7b911c