### PR TITLE
Fix dynamic choices function naming

### DIFF
--- a/location/urls.py
+++ b/location/urls.py
@@ -58,7 +58,7 @@ urlpatterns = [
     
     # AJAX endpoints
     path('ajax/location-types/', views.get_location_types, name='ajax-location-types'),
-    path('ajax/dynamic-choices/', views.get_dynamic_choices, name='ajax-dynamic-choices'),
+    path('ajax/dynamic-choices/', views.ajax_dynamic_choices, name='ajax-dynamic-choices'),
     
     # Legacy redirects (for backward compatibility)
     path('jobsite/<int:pk>/', views.legacy_jobsite_redirect, name='legacy-jobsite-redirect'),

--- a/location/views.py
+++ b/location/views.py
@@ -31,7 +31,7 @@ from .models import (
     LocationType,
     LocationDocument,
     LocationNote,
-    get_dynamic_choices,
+    get_dynamic_choices as model_get_dynamic_choices,
 )
 from .forms import (
     LocationForm,
@@ -276,16 +276,15 @@ def get_location_types(request):
 
 
 @login_required
-def get_dynamic_choices(request):
-    """AJAX view to get dynamic choices for a business category"""
+def ajax_dynamic_choices(request):
+    """AJAX view to fetch dynamic choices for a business category."""
     business_category_id = request.GET.get('business_category')
     choice_type = request.GET.get('choice_type')
-    
+
     choices = []
     if business_category_id and choice_type:
-        from .models import get_dynamic_choices
-        choices = get_dynamic_choices(choice_type, business_category_id)
-    
+        choices = model_get_dynamic_choices(choice_type, business_category_id)
+
     return JsonResponse({'choices': choices})
 
 
@@ -400,7 +399,7 @@ class LocationNoteListView(LoginRequiredMixin, ListView):
             followup_date__lt=context['today']
         ).count()
 
-        context['note_type_choices'] = get_dynamic_choices('note_type', location.business_category)
+        context['note_type_choices'] = model_get_dynamic_choices('note_type', location.business_category)
 
         return context
 


### PR DESCRIPTION
## Summary
- resolve name conflict in dynamic choices view
- update URLs to point to new `ajax_dynamic_choices` view

## Testing
- `pytest -q` *(fails: SECRET_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0a32e2e88332a540f9163242ca14