### PR TITLE
Add business app routing and placeholder views

### DIFF
--- a/business/urls.py
+++ b/business/urls.py
@@ -1,0 +1,31 @@
+from django.urls import path
+from . import views
+
+app_name = 'business'
+
+urlpatterns = [
+    # Dashboard
+    path('', views.business_dashboard, name='dashboard'),
+
+    # Business Configurations
+    path('configurations/', views.BusinessConfigurationListView.as_view(), name='config-list'),
+    path('configurations/<slug:slug>/', views.BusinessConfigurationDetailView.as_view(), name='config-detail'),
+
+    # Business Types
+    path('types/', views.BusinessTypeListView.as_view(), name='type-list'),
+    path('types/<slug:slug>/', views.BusinessTypeDetailView.as_view(), name='type-detail'),
+
+    # Business Templates
+    path('templates/', views.BusinessTemplateListView.as_view(), name='template-list'),
+    path('templates/<slug:slug>/', views.BusinessTemplateDetailView.as_view(), name='template-detail'),
+    path('templates/<slug:template_slug>/apply/<uuid:company_id>/',
+         views.apply_template_to_company, name='apply-template'),
+
+    # Setup Wizard
+    path('setup/', views.business_setup_wizard, name='setup-wizard'),
+
+    # API Endpoints
+    path('api/configurations/', views.business_config_api, name='config-api'),
+    path('api/templates/', views.business_template_api, name='template-api'),
+    path('api/categories/', views.project_categories_api, name='categories-api'),
+]

--- a/business/views.py
+++ b/business/views.py
@@ -1,0 +1,90 @@
+from django.shortcuts import render, get_object_or_404, redirect
+from django.urls import reverse
+from django.views import generic
+from django.http import JsonResponse
+from django.contrib import messages
+
+from .models import (
+    BusinessConfiguration,
+    BusinessType,
+    BusinessTemplate,
+    ProjectCategory,
+)
+from company.models import Company
+
+
+def business_dashboard(request):
+    """Simple dashboard placeholder"""
+    return render(request, 'business/dashboard.html')
+
+
+class BusinessConfigurationListView(generic.ListView):
+    model = BusinessConfiguration
+    template_name = 'business/configuration_list.html'
+    context_object_name = 'configs'
+
+
+class BusinessConfigurationDetailView(generic.DetailView):
+    model = BusinessConfiguration
+    slug_field = 'slug'
+    template_name = 'business/configuration_detail.html'
+    context_object_name = 'config'
+
+
+class BusinessTypeListView(generic.ListView):
+    model = BusinessType
+    template_name = 'business/type_list.html'
+    context_object_name = 'types'
+
+
+class BusinessTypeDetailView(generic.DetailView):
+    model = BusinessType
+    slug_field = 'slug'
+    template_name = 'business/type_detail.html'
+    context_object_name = 'type'
+
+
+class BusinessTemplateListView(generic.ListView):
+    model = BusinessTemplate
+    template_name = 'business/template_list.html'
+    context_object_name = 'templates'
+
+
+class BusinessTemplateDetailView(generic.DetailView):
+    model = BusinessTemplate
+    slug_field = 'slug'
+    template_name = 'business/template_detail.html'
+    context_object_name = 'template'
+
+
+def apply_template_to_company(request, template_slug, company_id):
+    template = get_object_or_404(BusinessTemplate, slug=template_slug)
+    company = get_object_or_404(Company, id=company_id)
+    template.apply_to_company(company)
+    messages.success(request, 'Template applied successfully.')
+    return redirect('company:detail', pk=company.id)
+
+
+def business_setup_wizard(request):
+    return render(request, 'business/setup_wizard.html')
+
+
+def business_config_api(request):
+    data = list(
+        BusinessConfiguration.objects.values('id', 'name', 'slug')
+    )
+    return JsonResponse({'configs': data})
+
+
+def business_template_api(request):
+    data = list(
+        BusinessTemplate.objects.filter(is_active=True).values('id', 'name', 'slug')
+    )
+    return JsonResponse({'templates': data})
+
+
+def project_categories_api(request):
+    data = list(
+        ProjectCategory.objects.filter(is_active=True).values('id', 'name', 'slug')
+    )
+    return JsonResponse({'categories': data})

--- a/wbee/urls.py
+++ b/wbee/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path("filer/", include("filer.urls")),
     path("hr/", include("hr.urls")),
     path("company/", include("company.urls")),
+    path("business/", include("business.urls")),
     path("location/", include("location.urls")),
     path('project/', include('project.urls')),
     path('material/', include('material.urls')),


### PR DESCRIPTION
## Summary
- add URL routes for the new `business` app
- implement stub views for business dashboard, config, type and template endpoints
- hook the business app into the main project URLs

## Testing
- `pytest -q` *(fails: 89 failed, 26 passed, 13 errors)*

------
https://chatgpt.com/codex/tasks/task_e_685e3355ef4c8332b33326250e14d8b2