### PR TITLE
Add business app URLs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Major apps included in this project are:
 - **asset** – Manage company assets and categories.
 - **client** – Customer records, addresses and contacts.
 - **company** – Core company/organization information.
+- **business** – Manage business types, configurations and templates.
 - **helpdesk** – Ticket tracking and knowledge base.
 - **hr** – Human resources: workers and positions.
 - **location** – Business locations and configurable choices.

--- a/business/urls.py
+++ b/business/urls.py
@@ -1,0 +1,33 @@
+# business/urls.py - Modern URL Configuration for Business Management
+
+from django.urls import path
+from . import views
+
+app_name = 'business'
+
+urlpatterns = [
+    # Dashboard
+    path('', views.business_dashboard, name='dashboard'),
+
+    # Business Configurations
+    path('configurations/', views.BusinessConfigurationListView.as_view(), name='config-list'),
+    path('configurations/<slug:slug>/', views.BusinessConfigurationDetailView.as_view(), name='config-detail'),
+
+    # Business Types
+    path('types/', views.BusinessTypeListView.as_view(), name='type-list'),
+    path('types/<slug:slug>/', views.BusinessTypeDetailView.as_view(), name='type-detail'),
+
+    # Business Templates
+    path('templates/', views.BusinessTemplateListView.as_view(), name='template-list'),
+    path('templates/<slug:slug>/', views.BusinessTemplateDetailView.as_view(), name='template-detail'),
+    path('templates/<slug:template_slug>/apply/<uuid:company_id>/',
+         views.apply_template_to_company, name='apply-template'),
+
+    # Setup Wizard
+    path('setup/', views.business_setup_wizard, name='setup-wizard'),
+
+    # API Endpoints
+    path('api/configurations/', views.business_config_api, name='config-api'),
+    path('api/templates/', views.business_template_api, name='template-api'),
+    path('api/categories/', views.project_categories_api, name='categories-api'),
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 import os
 import django
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "wbee.settings.base")
+os.environ.setdefault("SECRET_KEY", "test-secret")
+
 
 def pytest_configure():
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "wbee.settings.base")
     django.setup()

--- a/tests/test_business_urls.py
+++ b/tests/test_business_urls.py
@@ -1,0 +1,8 @@
+from django.urls import reverse, resolve
+from business.views import business_dashboard
+
+
+def test_dashboard_url_resolves(db):
+    path = reverse('business:dashboard')
+    assert path == '/business/'
+    assert resolve(path).func == business_dashboard

--- a/wbee/urls.py
+++ b/wbee/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path("filer/", include("filer.urls")),
     path("hr/", include("hr.urls")),
     path("company/", include("company.urls")),
+    path("business/", include("business.urls")),
     path("location/", include("location.urls")),
     path('project/', include('project.urls')),
     path('material/', include('material.urls')),


### PR DESCRIPTION
## Summary
- configure URL patterns for the new `business` app
- integrate the business app in the project URLconf
- document the app in the README
- ensure tests can set up Django settings
- add test covering basic business URL

## Testing
- `SECRET_KEY=test DATABASE_URL=sqlite:///:memory: pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_685e362b1af0833298e2ac71b02fa31c