### PR TITLE
Fix breadcrumbs and add companies link to dashboard

### DIFF
--- a/company/templates/company/base_company.html
+++ b/company/templates/company/base_company.html
@@ -99,7 +99,7 @@
 {% block breadcrumb %}
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb breadcrumb-modern">
-        <li class="breadcrumb-item"><a href="{% url 'home:index' %}"><i class="fas fa-home"></i> Home</a></li>
+        <li class="breadcrumb-item"><a href="{% url 'home:index' %}"><i class="fas fa-home"></i> Dashboard</a></li>
         {% block company_breadcrumb %}
         <li class="breadcrumb-item"><a href="{% url 'company:list' %}">Companies</a></li>
         {% endblock %}

--- a/home/templates/home/home.html
+++ b/home/templates/home/home.html
@@ -215,6 +215,16 @@
         </a>
     </div>
     <div class="col">
+        <a href="{% url 'company:list' %}" class="text-decoration-none">
+            <div class="card text-center h-100">
+                <div class="card-body">
+                    <i class="fas fa-industry fa-2x mb-2 text-primary"></i>
+                    <div>Companies</div>
+                </div>
+            </div>
+        </a>
+    </div>
+    <div class="col">
         <a href="{% url 'asset:list' %}" class="text-decoration-none">
             <div class="card text-center h-100">
                 <div class="card-body">
@@ -305,6 +315,7 @@
         <li><a class="dropdown-item" href="{% url 'project:project-list' %}"><i class="fas fa-wrench me-2 text-primary"></i>Projects</a></li>
         <li><a class="dropdown-item" href="{% url 'location:location-list' %}"><i class="fas fa-building me-2 text-secondary"></i>Locations</a></li>
         <li><a class="dropdown-item" href="{% url 'client:list' %}"><i class="fas fa-id-card me-2 text-info"></i>Clients</a></li>
+        <li><a class="dropdown-item" href="{% url 'company:list' %}"><i class="fas fa-industry me-2 text-primary"></i>Companies</a></li>
         <li><a class="dropdown-item" href="{% url 'asset:list' %}"><i class="fas fa-toolbox me-2 text-warning"></i>Assets</a></li>
         <li><a class="dropdown-item" href="{% url 'hr:worker-list' %}"><i class="fas fa-users me-2 text-success"></i>Staff</a></li>
         <li><a class="dropdown-item" href="{% url 'timecard:list' %}"><i class="fas fa-clock me-2 text-danger"></i>Time Cards</a></li>


### PR DESCRIPTION
## Summary
- update company breadcrumb to use Dashboard label
- add quick link to Companies on the Dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685e41f1bbdc83328b5af5daba3e79d3