### PR TITLE
Fix breadcrumb duplication

### DIFF
--- a/company/templates/company/base_company.html
+++ b/company/templates/company/base_company.html
@@ -97,14 +97,9 @@
 {% endblock %}
 
 {% block breadcrumb %}
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb breadcrumb-modern">
-        <li class="breadcrumb-item"><a href="{% url 'home:index' %}"><i class="fas fa-home"></i> Dashboard</a></li>
-        {% block company_breadcrumb %}
-        <li class="breadcrumb-item"><a href="{% url 'company:list' %}">Companies</a></li>
-        {% endblock %}
-    </ol>
-</nav>
+    {% block company_breadcrumb %}
+    <li class="breadcrumb-item"><a href="{% url 'company:list' %}">Companies</a></li>
+    {% endblock %}
 {% endblock %}
 
 {% block content %}

--- a/location/templates/location/dashboard.html
+++ b/location/templates/location/dashboard.html
@@ -12,12 +12,7 @@
 {% endblock %}
 
 {% block breadcrumb %}
-<nav aria-label="breadcrumb" class="mb-4">
-  <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
     <li class="breadcrumb-item active" aria-current="page">Location Dashboard</li>
-  </ol>
-</nav>
 {% endblock %}
 
 {% block content %}

--- a/location/templates/location/document_confirm_delete.html
+++ b/location/templates/location/document_confirm_delete.html
@@ -10,16 +10,11 @@
 {% endblock %}
 
 {% block breadcrumb %}
-<nav aria-label="breadcrumb" class="mb-4">
-  <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
     <li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
     <li class="breadcrumb-item"><a href="{{ object.location.get_absolute_url }}">{{ object.location.name }}</a></li>
     <li class="breadcrumb-item"><a href="{{ object.location.get_absolute_url }}#documents-tab">Documents</a></li>
     <li class="breadcrumb-item"><a href="{{ object.get_absolute_url }}">{{ object.title }}</a></li>
     <li class="breadcrumb-item active" aria-current="page">Delete</li>
-  </ol>
-</nav>
 {% endblock %}
 
 {% block content %}

--- a/location/templates/location/document_detail.html
+++ b/location/templates/location/document_detail.html
@@ -11,15 +11,10 @@
 {% endblock %}
 
 {% block breadcrumb %}
-<nav aria-label="breadcrumb" class="mb-4">
-  <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
     <li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
     <li class="breadcrumb-item"><a href="{{ document.location.get_absolute_url }}">{{ document.location.name }}</a></li>
     <li class="breadcrumb-item"><a href="{{ document.location.get_absolute_url }}#documents-tab">Documents</a></li>
     <li class="breadcrumb-item active" aria-current="page">{{ document.title }}</li>
-  </ol>
-</nav>
 {% endblock %}
 
 {% block content %}

--- a/location/templates/location/document_form.html
+++ b/location/templates/location/document_form.html
@@ -13,16 +13,11 @@
 {% endblock %}
 
 {% block breadcrumb %}
-<nav aria-label="breadcrumb" class="mb-4">
-  <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
     <li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
     <li class="breadcrumb-item"><a href="{{ location.get_absolute_url }}">{{ location.name }}</a></li>
     <li class="breadcrumb-item active" aria-current="page">
       {% if form.instance.pk %}Edit Document{% else %}Upload Document{% endif %}
     </li>
-  </ol>
-</nav>
 {% endblock %}
 
 {% block content %}

--- a/location/templates/location/document_list.html
+++ b/location/templates/location/document_list.html
@@ -11,14 +11,9 @@
 {% endblock %}
 
 {% block breadcrumb %}
-<nav aria-label="breadcrumb" class="mb-4">
-  <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
     <li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
     <li class="breadcrumb-item"><a href="{{ location.get_absolute_url }}">{{ location.name }}</a></li>
     <li class="breadcrumb-item active" aria-current="page">Documents</li>
-  </ol>
-</nav>
 {% endblock %}
 
 {% block content %}

--- a/location/templates/location/location_form.html
+++ b/location/templates/location/location_form.html
@@ -5,8 +5,6 @@
 {% block title %}{% if form.instance.pk %}Edit {{ form.instance.name }}{% else %}Add New Location{% endif %}{% endblock %}
 
 {% block breadcrumb %}
-<nav aria-label="breadcrumb">
-  <ol class="breadcrumb">
     <li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
     <li class="breadcrumb-item"><a href="{% url 'location:location-list' %}">All Locations</a></li>
     {% if form.instance.pk %}
@@ -15,8 +13,6 @@
     {% else %}
     <li class="breadcrumb-item active" aria-current="page">Add Location</li>
     {% endif %}
-  </ol>
-</nav>
 {% endblock %}
 
 {% block content %}

--- a/location/templates/location/location_map.html
+++ b/location/templates/location/location_map.html
@@ -12,13 +12,8 @@
 {% endblock %}
 
 {% block breadcrumb %}
-<nav aria-label="breadcrumb" class="mb-4">
-  <ol class="breadcrumb">
-    <li class="breadcrumb-item"><a href="{% url 'home:index' %}">Home</a></li>
     <li class="breadcrumb-item"><a href="{% url 'location:dashboard' %}">Locations</a></li>
     <li class="breadcrumb-item active" aria-current="page">Map View</li>
-  </ol>
-</nav>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- update `base_company.html` breadcrumb block
- simplify breadcrumbs for several location templates

## Testing
- `pytest -q` *(fails: SECRET_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4680773483328e0e8697cedc667c