### PR TITLE
Use generic inline formsets for company addresses and contacts

### DIFF
--- a/company/forms.py
+++ b/company/forms.py
@@ -505,10 +505,10 @@ class CompanySearchForm(forms.Form):
 
 # Formsets for inline editing
 from django.forms import inlineformset_factory
+from django.contrib.contenttypes.forms import generic_inlineformset_factory
 
 # Address formset for companies
-CompanyAddressFormSet = inlineformset_factory(
-    Company,
+CompanyAddressFormSet = generic_inlineformset_factory(
     Address,
     form=AddressForm,
     extra=1,
@@ -517,8 +517,7 @@ CompanyAddressFormSet = inlineformset_factory(
 )
 
 # Contact formset for companies  
-CompanyContactFormSet = inlineformset_factory(
-    Company,
+CompanyContactFormSet = generic_inlineformset_factory(
     Contact,
     form=ContactForm,
     extra=1,


### PR DESCRIPTION
## Summary
- use `generic_inlineformset_factory` for company address and contact formsets

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError and database settings)*

------
https://chatgpt.com/codex/tasks/task_e_685e55eea6908332a71efbf5b3119bc0