### PR TITLE
Fix jobsite creation link

### DIFF
--- a/client/templates/client/client_list.html
+++ b/client/templates/client/client_list.html
@@ -386,7 +386,7 @@ Client Directory - {{ request.user.company.company_name|default:"WBEE" }}
                     <i class="fas fa-edit me-2"></i>Edit Client
                   </a>
                   <div class="dropdown-divider"></div>
-                  <a class="dropdown-item" href="{% url 'create-jobsite-from' client=client.pk %}">
+                  <a class="dropdown-item" href="{% url 'location:location-create' %}?client={{ client.pk }}">
                     <i class="fas fa-plus me-2"></i>Add Job Site
                   </a>
                   {% endif %}


### PR DESCRIPTION
## Summary
- fix client list job site creation link to use location module

## Testing
- `bash codex_setup.sh` *(fails: SECRET_KEY not found)*
- `pytest -q` *(fails: SECRET_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f3692f2b88332af0d424fd6ce2fea