### PR TITLE
Use job position for permissions

### DIFF
--- a/hr/models.py
+++ b/hr/models.py
@@ -405,6 +405,13 @@ class Worker(AbstractBaseUser, UUIDModel, TimeStampedModel):
             return "admin"
         if self.is_staff:
             return "staff"
+        if self.position:
+            from django.conf import settings
+            mapping = getattr(settings, 'POSITION_ROLE_MAP', {})
+            role = mapping.get(getattr(self.position, 'position_code', None)) or \
+                   mapping.get(getattr(self.position, 'title', None))
+            if role:
+                return role
         return ""
 
     @role.setter

--- a/wbee/settings/base.py
+++ b/wbee/settings/base.py
@@ -448,6 +448,14 @@ COMPANY_WEBSITE = config('COMPANY_WEBSITE', default='https://wbee.app')
 FILE_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10MB
 DATA_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10MB
 
+# Mapping of job position codes to default roles used for permissions
+POSITION_ROLE_MAP = {
+    # Example mappings; customize to match your organization's positions
+    'PMGR': 'project_manager',
+    'SUPV': 'supervisor',
+    'WORK': 'worker',
+}
+
 # ==============================================================================
 # ENVIRONMENT-SPECIFIC OVERRIDES
 # ==============================================================================


### PR DESCRIPTION
## Summary
- map job positions to default roles in settings
- let `Worker.role` derive from the user's position when no explicit role is set

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: SECRET_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f364f6ba0833299a91754ec7b1ee5