### PR TITLE
Use job position for permissions

### DIFF
--- a/hr/models.py
+++ b/hr/models.py
@@ -405,6 +405,13 @@ class Worker(AbstractBaseUser, UUIDModel, TimeStampedModel):
             return "admin"
         if self.is_staff:
             return "staff"
+        if self.position:
+            from django.conf import settings
+            mapping = getattr(settings, 'POSITION_ROLE_MAP', {})
+            role = mapping.get(getattr(self.position, 'position_code', None)) or \
+                   mapping.get(getattr(self.position, 'title', None))
+            if role:
+                return role
         return ""
 
     @role.setter

--- a/project/permissions.py
+++ b/project/permissions.py
@@ -35,6 +35,8 @@ class ProjectAccessMixin(UserPassesTestMixin):
                 )
             elif user.role == "worker":
                 return user in project.team_members.all()
+            elif user.role == "staff":
+                return True
             elif user.role == "client":
                 return hasattr(user, "client") and project.location.client == user.client
 

--- a/project/templates/project/project_detail_full.html
+++ b/project/templates/project/project_detail_full.html
@@ -17,7 +17,7 @@
             <h4>{{ project.name }} : {{ project.job_number }}{% if project.revision %}-{{ project.revision }}{% endif %}</h4>
           </div>
           <div class="col-lg-12">
-            {% if request.user.is_staff %}
+            {% if request.user.is_staff and request.user.role != 'staff' %}
               <a href="{% url 'project:project-pdf' project.job_number %}"><div class="add_jobsite"> Quote </div></a>&nbsp;<a href="{% url 'project:project-edit' project.job_number %}"><div class="add_jobsite"> edit </div></a>
             {% endif %}
           </div>
@@ -65,7 +65,7 @@
       <div class="card-header" style="background-color:rgb(0, 119, 255);">
           <div class"row">
             <b>Scope of work:</b>
-            {% if request.user.is_staff %}
+            {% if request.user.is_staff and request.user.role != 'staff' %}
               <a href="{% url 'project:scope-create' job_number=project.job_number %}"><div class="add_jobsite"> + add </div></a>
             {% endif %}
           </div>
@@ -101,7 +101,7 @@
   <div class="col-lg-4">
     <div class="card mb-3">
       <div class="card-header" style="background-color:rgb(0, 119, 255);"><b>Scheduled Work</b>
-        {% if request.user.is_staff %}
+        {% if request.user.is_staff and request.user.role != 'staff' %}
           <a href="{% url 'create-event' proj=project.job_number %}"><div class="add_jobsite"> + add work</div></a>
         {% endif %}
       </div>
@@ -120,7 +120,7 @@
       </div>
       <div class="card mb-3">
         <div class="card-header"><b>Devices</b>
-          {% if request.user.is_staff %}
+          {% if request.user.is_staff and request.user.role != 'staff' %}
             <a href="{% url 'project:device-create' job_number=project.job_number %}"><div class="add_jobsite"> + add</div></a>
           {% endif %}
         </div>
@@ -142,7 +142,7 @@
 
       <div class="card mb-3">
         <div class="card-header"><b>Hardware</b>
-          {% if request.user.is_staff %}
+          {% if request.user.is_staff and request.user.role != 'staff' %}
             <a href="{% url 'project:hardware-create' job_number=project.job_number %}"><div class="add_jobsite"> + add</div></a>
           {% endif %}
         </div>
@@ -166,7 +166,7 @@
       </div>
       <div class="card mb-3">
         <div class="card-header"><b>Software</b>
-          {% if request.user.is_staff %}
+          {% if request.user.is_staff and request.user.role != 'staff' %}
             <a href="{% url 'project:software-create' job_number=project.job_number %}"><div class="add_jobsite"> + add</div></a>
           {% endif %}
         </div>
@@ -190,7 +190,7 @@
       </div>
       <div class="card mb-3">
         <div class="card-header"><b>License</b>
-          {% if request.user.is_staff %}
+          {% if request.user.is_staff and request.user.role != 'staff' %}
             <a href="{% url 'project:license-create' job_number=project.job_number %}"><div class="add_jobsite"> + add</div></a>
           {% endif %}
         </div>
@@ -214,7 +214,7 @@
       </div>
       <div class="card mb-3">
         <div class="card-header"><b>Travel</b>
-          {% if request.user.is_staff %}
+          {% if request.user.is_staff and request.user.role != 'staff' %}
             <a href="{% url 'project:travel-create' job_number=project.job_number %}"><div class="add_jobsite"> + add</div></a>
           {% endif %}
         </div>

--- a/project/views.py
+++ b/project/views.py
@@ -519,6 +519,9 @@ class ProjectDetailView(ProjectAccessMixin, DetailView):
             permissions.update({
                 'can_edit': user in project.team_members.all(),
             })
+        elif user.role == 'staff':
+            # allow viewing only
+            pass
         elif user.role == 'client':
             permissions.update({
                 'can_view_financials': True,

--- a/schedule/templates/schedule/dayevent_detail.html
+++ b/schedule/templates/schedule/dayevent_detail.html
@@ -16,7 +16,7 @@
         <h4>
           <a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">
           <i class="fa fa-fw fa-calendar"></i> {{dayevent.day_of_event|date:"SHORT_DATE_FORMAT"}}</a><br>{{dayevent.days_of_event}}
-          {% if request.user.is_staff %}
+          {% if request.user.is_staff and request.user.role != 'staff' %}
             <div class="add_jobsite"><a href="{% url 'update-dayevent' dayevent.pk %}"> edit </a></div>
           {% else %}
           {% endif %}

--- a/schedule/templates/schedule/event.html
+++ b/schedule/templates/schedule/event.html
@@ -10,7 +10,7 @@
 
 {% block content %}
 
-    {% if request.user.is_staff %}
+    {% if request.user.is_staff and request.user.role != 'staff' %}
 <div class="row">
   <div class="col-lg-2">
       <a href="{% url 'delete_event' event.id %}"> <i class="fa fa-trash"></i> delete </a> -

--- a/timecard/templates/timecard/timecard_list.html
+++ b/timecard/templates/timecard/timecard_list.html
@@ -10,7 +10,9 @@
 <div class="card">
   <div class="card-header d-flex justify-content-between align-items-center">
     <h5 class="mb-0">My Timecards</h5>
+    {% if request.user.is_staff and request.user.role != 'staff' %}
     <a href="{% url 'timecard:create' %}" class="btn btn-sm btn-primary">Add Entry</a>
+    {% endif %}
   </div>
   <div class="card-body">
     <table id="timecardTable" class="table table-striped table-bordered">

--- a/todo/templates/todo/task_detail.html
+++ b/todo/templates/todo/task_detail.html
@@ -92,7 +92,7 @@
   <div class="col-lg-4">
     <div class="card mb-3">
       <div class="card-header"><b>Devices</b>
-        {% if request.user.is_staff %}
+        {% if request.user.is_staff and request.user.role != 'staff' %}
           <a href="{% url 'project:device-create' job_number=task.task_list.scope.project.job_number %}"><div class="add_jobsite"> + add</div></a>
         {% else %}
         {% endif %}
@@ -121,7 +121,7 @@
   <div class="col-lg-4">
     <div class="card mb-3">
       <div class="card-header"><b>Hardware</b> - <a href="">details</a>
-        {% if request.user.is_staff %}
+        {% if request.user.is_staff and request.user.role != 'staff' %}
           <a href="{% url 'project:hardware-create' job_number=task.task_list.scope.project.job_number %}"><div class="add_jobsite"> + add</div></a>
         {% else %}
         {% endif %}
@@ -149,7 +149,7 @@
   <div class="col-lg-4">
     <div class="card mb-3">
       <div class="card-header"><b>Software</b> - <a href="">details</a>
-        {% if request.user.is_staff %}
+        {% if request.user.is_staff and request.user.role != 'staff' %}
           <a href="{% url 'project:software-create' job_number=task.task_list.scope.project.job_number %}"><div class="add_jobsite"> + add</div></a>
         {% else %}
         {% endif %}
@@ -177,7 +177,7 @@
   <div class="col-lg-4">
     <div class="card mb-3">
       <div class="card-header"><b>License</b> - <a href="">details</a>
-        {% if request.user.is_staff %}
+        {% if request.user.is_staff and request.user.role != 'staff' %}
           <a href="{% url 'project:license-create' job_number=task.task_list.scope.project.job_number %}"><div class="add_jobsite"> + add</div></a>
         {% else %}
         {% endif %}
@@ -205,7 +205,7 @@
   <div class="col-lg-4">
     <div class="card mb-3">
       <div class="card-header"><b>Travel</b>
-        {% if request.user.is_staff %}
+        {% if request.user.is_staff and request.user.role != 'staff' %}
           <a href="{% url 'project:travel-create' job_number=task.task_list.scope.project.job_number %}"><div class="add_jobsite"> + add</div></a>
         {% else %}
         {% endif %}

--- a/wbee/settings/base.py
+++ b/wbee/settings/base.py
@@ -448,6 +448,14 @@ COMPANY_WEBSITE = config('COMPANY_WEBSITE', default='https://wbee.app')
 FILE_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10MB
 DATA_UPLOAD_MAX_MEMORY_SIZE = 10 * 1024 * 1024  # 10MB
 
+# Mapping of job position codes to default roles used for permissions
+POSITION_ROLE_MAP = {
+    # Example mappings; customize to match your organization's positions
+    'PMGR': 'project_manager',
+    'SUPV': 'supervisor',
+    'WORK': 'worker',
+}
+
 # ==============================================================================
 # ENVIRONMENT-SPECIFIC OVERRIDES
 # ==============================================================================


### PR DESCRIPTION
## Summary
- map job positions to default roles in settings
- let Worker.role derive from the user's position when no explicit role is set
- allow staff role to view project details
- hide add buttons for staff-only role

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: SECRET_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f364f6ba0833299a91754ec7b1ee5