### PR TITLE
Fix missing schedule URLs

### DIFF
--- a/schedule/templates/fullcalendar_script.html
+++ b/schedule/templates/fullcalendar_script.html
@@ -40,7 +40,8 @@ $(document).ready(function() {
     function setModalProperties(type, event){
         if(type == 'edit'){
             var tYPE = '{% trans "Edit" %}';
-            var all_url = "{% url 'edit_event' calendar_slug 12345 %}".replace(/12345/, event.event_id);
+            {% url 'edit_event' calendar_slug 12345 as edit_event_base %}
+            var all_url = "{{ edit_event_base }}".replace(/12345/, event.event_id);
             if (event.existed){
                 var this_url = "{% url 'edit_occurrence' 12345 6789 %}".replace(/12345/, event.event_id).replace(/6789/, event.id);
             }
@@ -57,7 +58,8 @@ $(document).ready(function() {
         }
         else if(type == 'delete'){
             var tYPE = '{% trans "Delete" %}';
-            var all_url = "{% url 'delete_event' 12345 %}".replace(/12345/, event.event_id);
+            {% url 'delete_event' 12345 as delete_event_base %}
+            var all_url = "{{ delete_event_base }}".replace(/12345/, event.event_id);
             if (event.existed){
                 var this_url = "{% url 'cancel_occurrence' 12345 6789 %}".replace(/12345/, event.event_id).replace(/6789/, event.id);
             }

--- a/schedule/templates/profiles/schedule.html
+++ b/schedule/templates/profiles/schedule.html
@@ -36,12 +36,18 @@
                     <img src="{{ settings.MEDIA_URL }}icons/time_go.png" alt="{% trans "Event details" %}">
                 </a>
                 {% if request.user == other_user %}
-                <a href="{% url "edit_event" calendar.slug event.pk %}" title="{% trans "Edit event" %} {{ event }}">
+                {% url "edit_event" calendar.slug event.pk as edit_event_url %}
+                {% url "delete_event" event.pk as delete_event_url %}
+                {% if edit_event_url %}
+                <a href="{{ edit_event_url }}" title="{% trans "Edit event" %} {{ event }}">
                     <img src="{{ settings.MEDIA_URL }}icons/time_edit.png" alt="{% trans "Edit event" %}">
                 </a>
-                <a href="{% url "delete_event" event.pk %}" title="{% trans "Delete event" %} {{ event }}">
+                {% endif %}
+                {% if delete_event_url %}
+                <a href="{{ delete_event_url }}" title="{% trans "Delete event" %} {{ event }}">
                     <img src="{{ settings.MEDIA_URL }}icons/time_delete.png" alt="{% trans "Delete event" %}">
                 </a>
+                {% endif %}
                 {% endif %}
                 {% endblock schedule_event_controls %}
             </td>

--- a/schedule/templates/schedule/event.html
+++ b/schedule/templates/schedule/event.html
@@ -11,10 +11,16 @@
 {% block content %}
 
     {% if request.user.is_staff %}
+    {% url 'delete_event' event.id as delete_event_url %}
+    {% url 'edit_event' event.calendar.slug event.id as edit_event_url %}
 <div class="row">
   <div class="col-lg-2">
-      <a href="{% url 'delete_event' event.id %}"> <i class="fa fa-trash"></i> delete </a> -
-      <a href="{% url 'edit_event' event.calendar.slug event.id  %}"><i class="fa fa-pencil"></i> edit</a>
+      {% if delete_event_url %}
+      <a href="{{ delete_event_url }}"> <i class="fa fa-trash"></i> delete </a>{% if edit_event_url %} -{% endif %}
+      {% endif %}
+      {% if edit_event_url %}
+      <a href="{{ edit_event_url }}"><i class="fa fa-pencil"></i> edit</a>
+      {% endif %}
   </div>
 </div>
     {% endif %}

--- a/schedule/templatetags/scheduletags.py
+++ b/schedule/templatetags/scheduletags.py
@@ -4,7 +4,7 @@ import datetime
 
 from django import template
 from django.conf import settings
-from django.urls import reverse
+from django.urls import reverse, NoReverseMatch
 from django.utils import timezone
 from django.utils.dateformat import format
 from django.utils.html import escape
@@ -91,8 +91,14 @@ def options(context, occurrence):
     if CHECK_EVENT_PERM_FUNC(occurrence.event, user) and CHECK_CALENDAR_PERM_FUNC(occurrence.event.calendar, user):
         context['edit_occurrence'] = occurrence.get_edit_url()
         context['cancel_occurrence'] = occurrence.get_cancel_url()
-        context['delete_event'] = reverse('delete_event', args=(occurrence.event.id,))
-        context['edit_event'] = reverse('edit_event', args=(occurrence.event.calendar.slug, occurrence.event.id,))
+        try:
+            context['delete_event'] = reverse('delete_event', args=(occurrence.event.id,))
+        except NoReverseMatch:
+            context['delete_event'] = ''
+        try:
+            context['edit_event'] = reverse('edit_event', args=(occurrence.event.calendar.slug, occurrence.event.id,))
+        except NoReverseMatch:
+            context['edit_event'] = ''
     else:
         context['edit_event'] = context['delete_event'] = ''
     return context


### PR DESCRIPTION
## Summary
- avoid NoReverseMatch for missing delete/edit views
- guard options tag URL generation
- avoid failing reverse lookups in event templates

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: TemplateSyntaxError: 'bootstrap' is not a registered tag library)*

------
https://chatgpt.com/codex/tasks/task_e_685f49693f38833282b650c4d20e791a