### PR TITLE
Fix project location display in event views

### DIFF
--- a/schedule/templates/schedule/dayevent_detail.html
+++ b/schedule/templates/schedule/dayevent_detail.html
@@ -53,15 +53,21 @@
           {% else %}statusLost
           {% endif %} ">Install: {{ dayevent.project.get_status_display|default:dayevent.project.status }}</p>
         
-        <strong><a href="{{ dayevent.project.jobsite.get_absolute_url }}">{{ dayevent.project.jobsite }}</a></strong> - 
-            (<a href="{{ dayevent.project.jobsite.job_client.get_absolute_url }}">{{ dayevent.project.jobsite.job_client }}</a>)
-        <br> 
-        <a href="{{ dayevent.project.jobsite.google_maps_link }}">
-          <h6>
-            {{ dayevent.project.jobsite.street_address }}<br>
-            {{ dayevent.project.jobsite.city }}, {{ dayevent.project.jobsite.state }} {{ dayevent.project.jobsite.zipcode }}
-          </h6>
-        </a>
+        {% with location=dayevent.project.location %}
+          {% if location %}
+            <strong><a href="{{ location.get_absolute_url }}">{{ location }}</a></strong>
+            - (<a href="{{ location.client.get_absolute_url }}">{{ location.client }}</a>)
+            <br>
+            {% if location.primary_address %}
+              <a href="{{ location.google_maps_url }}">
+                <h6>
+                  {{ location.primary_address.line1 }}<br>
+                  {{ location.primary_address.city }}, {{ location.primary_address.state_province }} {{ location.primary_address.postal_code }}
+                </h6>
+              </a>
+            {% endif %}
+          {% endif %}
+        {% endwith %}
         {% if dayevent.project.status != 'c' %}
         <strong>Due date:</strong> {{dayevent.project.due_date}}{% endif %}<br>
         <strong>Date of completion:</strong> {{ dayevent.project.finished_date }}

--- a/schedule/templates/schedule/event.html
+++ b/schedule/templates/schedule/event.html
@@ -52,15 +52,22 @@
               {% else %}statusLost
               {% endif %}">Status: {{ event.project.get_status_display|default:event.project.status }}</p>
             
-            <strong><a href="{{ event.project.jobsite.get_absolute_url }}">{{ event.project.jobsite }}</a></strong> - 
-                (<a href="{{ event.project.jobsite.job_client.get_absolute_url }}">{{ event.project.jobsite.job_client }}</a>)
-            <br> 
-            <a href="{{ event.project.jobsite.google_maps_link }}">
-              <h6>
-                {{ event.project.jobsite.street_address }}<br>
-                {{ event.project.jobsite.city }}, {{ event.project.jobsite.state }} {{ event.project.jobsite.zipcode }}
-              </h6>
-            </a>
+            {# Display associated location using the modern location model #}
+            {% with location=event.project.location %}
+              {% if location %}
+                <strong><a href="{{ location.get_absolute_url }}">{{ location }}</a></strong>
+                - (<a href="{{ location.client.get_absolute_url }}">{{ location.client }}</a>)
+                <br>
+                {% if location.primary_address %}
+                  <a href="{{ location.google_maps_url }}">
+                    <h6>
+                      {{ location.primary_address.line1 }}<br>
+                      {{ location.primary_address.city }}, {{ location.primary_address.state_province }} {{ location.primary_address.postal_code }}
+                    </h6>
+                  </a>
+                {% endif %}
+              {% endif %}
+            {% endwith %}
             {% if event.project.due_date %}
               {% if event.project.status != 'c' %}
                 <strong>Due date:</strong> {{ event.project.due_date }}

--- a/schedule/templates/schedule/event_archive_day.html
+++ b/schedule/templates/schedule/event_archive_day.html
@@ -60,7 +60,15 @@
             <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ event.get_absolute_url }}">{{ event.start_time|date:'f A' }}</a> </td>
             <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ event.get_absolute_url }}">{{ event.start|date:'f A' }}</a> </td>
             <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ event.project.get_absolute_url }}">{{ event.project.name|truncatechars:48 }}</a> </td>
-            <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ event.project.jobsite.google_maps_link }}">{{ event.project.jobsite.street_address }}, {{ event.project.jobsite.city }}, {{ event.project.jobsite.state }}, {{ event.project.jobsite.zipcode }}</a></td>
+            {% with location=event.project.location %}
+              <td style="min-width:220px;font-weight:bold;">
+                {% if location and location.primary_address %}
+                  <a style="color:black;" href="{{ location.google_maps_url }}">
+                    {{ location.primary_address.line1 }}, {{ location.primary_address.city }}, {{ location.primary_address.state_province }}, {{ location.primary_address.postal_code }}
+                  </a>
+                {% endif %}
+              </td>
+            {% endwith %}
             <td style="min-width:64px;font-weight:bold;"><a style="color:black;" href="{{ event.project.get_absolute_url }}">{{ event.project.job_number }}</a> </td>
           </tr>
         {% if not forloop.last %} {% endif %}

--- a/schedule/templates/schedule/schedule_day_list.html
+++ b/schedule/templates/schedule/schedule_day_list.html
@@ -56,7 +56,15 @@
             <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">{{ dayevent.start_time|date:"f A" }}</a> </td>
             <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">{{ dayevent.start|date:"f A" }}</a> </td>
             <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.name|truncatechars:48 }}</a> </td>
-            <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.jobsite.google_maps_link }}">{{ dayevent.project.jobsite.street_address }}, {{ dayevent.project.jobsite.city }}, {{ dayevent.project.jobsite.state }}, {{ dayevent.project.jobsite.zipcode }}</a></td>
+            {% with location=dayevent.project.location %}
+              <td style="min-width:220px;font-weight:bold;">
+                {% if location and location.primary_address %}
+                  <a style="color:black;" href="{{ location.google_maps_url }}">
+                    {{ location.primary_address.line1 }}, {{ location.primary_address.city }}, {{ location.primary_address.state_province }}, {{ location.primary_address.postal_code }}
+                  </a>
+                {% endif %}
+              </td>
+            {% endwith %}
             <td style="min-width:64px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.job_number }}</a> </td>
           </tr>
         {% if not forloop.last %} {% endif %}
@@ -73,7 +81,15 @@
           <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">{{ dayevent.start_time|date:"f A" }}</a> </td>
           <td style="min-width:92px;font-weight:bold;"><a style="color:black;font-weight:bold;" href="{{ dayevent.get_absolute_url }}">{{ dayevent.start|date:"f A" }}</a> </td>
           <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.name|truncatechars:48 }}</a> </td>
-          <td style="min-width:220px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.jobsite.google_maps_link }}">{{ dayevent.project.jobsite.street_address }}, {{ dayevent.project.jobsite.city }}, {{ dayevent.project.jobsite.state }}, {{ dayevent.project.jobsite.zipcode }}</a></td>
+          {% with location=dayevent.project.location %}
+            <td style="min-width:220px;font-weight:bold;">
+              {% if location and location.primary_address %}
+                <a style="color:black;" href="{{ location.google_maps_url }}">
+                  {{ location.primary_address.line1 }}, {{ location.primary_address.city }}, {{ location.primary_address.state_province }}, {{ location.primary_address.postal_code }}
+                </a>
+              {% endif %}
+            </td>
+          {% endwith %}
           <td style="min-width:64px;font-weight:bold;"><a style="color:black;" href="{{ dayevent.project.get_absolute_url }}">{{ dayevent.project.job_number }}</a> </td>
           </tr>
         {% if not forloop.last %} {% endif %}


### PR DESCRIPTION
## Summary
- fix event templates to reference Project location model instead of legacy jobsite
- show location name, client and primary address with map link

## Testing
- `bash codex_setup.sh` *(fails: SECRET_KEY not found)*
- `pytest -q` *(fails: SECRET_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f4b851e2c8332ba95e8e927620c9b