### PR TITLE
Fix event buttons to link to details

### DIFF
--- a/schedule/templates/schedule/_daily_table.html
+++ b/schedule/templates/schedule/_daily_table.html
@@ -10,11 +10,10 @@
     </td>
     <td class="col-md-4">
       {% for occ in slot.occurrences %}
-      <button type="button"  class="btn {% if occ.cancelled %} btn-danger {%else%} btn-primary {% endif %}" data-toggle="modal" data-target="#{% hash_occurrence occ %}" {% if occ.event.color_event %} style="background-color: {{occ.event.color_event}};border-color:{{occ.event.color_event}}" {% endif %}>
+      <a class="btn {% if occ.cancelled %} btn-danger {% else %} btn-primary {% endif %}" href="{{ occ.event.get_absolute_url }}" {% if occ.event.color_event %} style="background-color: {{occ.event.color_event}};border-color:{{occ.event.color_event}}" {% endif %}>
                   {% options occ %}
                   {% title occ %}
-            </button>
-      {% include 'schedule/_detail.html' with occurrence=occ %}
+      </a>
       {% endfor %}
     </td>
   </tr>

--- a/schedule/templates/schedule/_day_cell_big copy.html
+++ b/schedule/templates/schedule/_day_cell_big copy.html
@@ -2,7 +2,7 @@
 <div>
   {% if day.has_occurrences %}
       {% for o in day.get_occurrence_partials %}
-              <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#occurrenceModal">
+              <a class="btn btn-primary btn-lg" href="{{ o.occurrence.event.get_absolute_url }}">
 
                   <div class="starttime">
                       {% if o.class == 0 %}{{ o.occurrence.start|time:"G:i" }}{% endif %}
@@ -13,22 +13,7 @@
                   <div class="eventdesc">
                       {% title o.occurrence %}
                   </div>
-              </div>
-              <div class="modal fade" id="occurrenceModal" tabindex="-1" role="dialog" aria-labelledby="occurrence_detailsl">
-                <div class="modal-dialog" role="document">
-                  <div class="modal-content">
-                    <div class="modal-header">
-                      <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title" id="myModalLabel">{{ o.occurrence.title }}</h4>
-                    </div>
-                    <div class="">XXX
-                      {% include 'schedule/_detail.html' with occurrence=o.occurrence %}
-                    </div>
-                   <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                  </div>
-                </div>
-              </div>
+              </a>
       {% endfor %}
   {% endif %}
 </div>

--- a/schedule/templates/schedule/_day_cell_big.html
+++ b/schedule/templates/schedule/_day_cell_big.html
@@ -2,7 +2,7 @@
 <div>
   {% if day.has_occurrences %}
       {% for o in day.get_occurrence_partials %}
-              <button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="">
+              <a class="btn btn-primary btn-lg" href="{{ o.occurrence.event.get_absolute_url }}">
 
                   <div class="starttime">
                       {% if o.class == 0 %}{{ o.occurrence.start|time:"G:i" }}{% endif %}
@@ -13,22 +13,7 @@
                   <div class="eventdesc">
                       {% title o.occurrence %}
                   </div>
-              </div>
-              <div class="modal fade" id="occurrenceModal" tabindex="-1" role="dialog" aria-labelledby="occurrence_detailsl">
-                <div class="modal-dialog" role="document">
-                  <div class="modal-content">
-                    <div class="modal-header">
-                      <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                        <h4 class="modal-title" id="myModalLabel">{{ o.occurrence.title }}</h4>
-                    </div>
-                    <div class="">XXX
-                      {% include 'schedule/_detail.html' with occurrence=o.occurrence %}
-                    </div>
-                   <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                  </div>
-                </div>
-              </div>
+              </a>
       {% endfor %}
   {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- make day calendar event buttons link to event detail pages
- remove unused modal markup from day calendar cells

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685f502e7a5c8332a1cabd705c07e234