### PR TITLE
Highlight event days in year calendar

### DIFF
--- a/schedule/templates/schedule/_day_cell.html
+++ b/schedule/templates/schedule/_day_cell.html
@@ -3,7 +3,11 @@
   <td style="color:blue;" class="muted"></td>
 {% else %}
   {% if day.has_occurrences %}
+    {% if size == "small" %}
+    <td style="color:blue;" class="btn-primary sched_day gradient calendr-day year-event-day">
+    {% else %}
     <td style="color:blue;" class="btn-primary sched_day gradient calendr-day">
+    {% endif %}
   {% else %}
     <td style="color:blue;">
   {% endif %}

--- a/schedule/templates/schedule/calendar_year.html
+++ b/schedule/templates/schedule/calendar_year.html
@@ -3,6 +3,9 @@
 {% load scheduletags i18n %}
 
 {% block title %}{{ calendar.name }} - Year{% endblock %}
+{% block styler %}
+  <link rel="stylesheet" href="{% static 'schedule/schedule.css' %}" type="text/css" media="screen">
+{% endblock %}
 {% block content %}
 
 <div class="tablewrapper">

--- a/static/schedule/schedule.css
+++ b/static/schedule/schedule.css
@@ -96,3 +96,12 @@ fieldset[disabled] .btn-custom.active {
 .sched_container{background-color:none}
 .sched_container{box-sizing:border-box;border:1px solid #CECECE;box-shadow:2px 2px 5px #CCC;border-radius:3px}
 .calendarname{float:right;}
+
+/* Highlight days with events specifically in the year view */
+.year-event-day {
+  background-color: #ffe082;
+}
+
+.year-event-day:hover {
+  background-color: #ffd54f;
+}


### PR DESCRIPTION
## Summary
- style event days in year view via `.year-event-day`
- include schedule styling on year calendar page
- apply `.year-event-day` class to small day cells

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685f5246191c8332a1e5e5a673a0a745