### PR TITLE
Fix permissions for worker todo access

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -531,3 +531,8 @@ def schedule_demo(request):
     """Simple demo view showing scheduled events snippet."""
     return render(request, "home/schedule_example.html")
 
+
+def permission_denied_view(request, exception=None):
+    """Render custom 403 page."""
+    return render(request, "403.html", status=403)
+

--- a/templates/403.html
+++ b/templates/403.html
@@ -1,0 +1,11 @@
+{% extends 'home/base.html' %}
+{% block title %}Permission Denied{% endblock %}
+{% block breadcrumb %}
+<li class="breadcrumb-item active">Forbidden</li>
+{% endblock %}
+{% block content %}
+<div class="text-center mt-5">
+    <h1 class="display-4">403 Forbidden</h1>
+    <p class="lead">You do not have permission to access this page.</p>
+</div>
+{% endblock %}

--- a/todo/utils.py
+++ b/todo/utils.py
@@ -13,7 +13,8 @@ def staff_check(user):
     """
 
     if hasattr(settings, "TODO_STAFF_ONLY") and settings.TODO_STAFF_ONLY:
-        return user.is_staff
+        # Allow access to staff and active workers
+        return user.is_staff or user.is_active
     else:
         # If unset or False, allow all logged in users
         return True

--- a/wbee/urls.py
+++ b/wbee/urls.py
@@ -44,3 +44,5 @@ urlpatterns += [
 
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+handler403 = 'home.views.permission_denied_view'


### PR DESCRIPTION
## Summary
- relax staff check to allow active workers
- add a custom permission denied view and page
- hook custom 403 handler in URLs

## Testing
- `pytest -q` *(fails: SECRET_KEY not found, database URL unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68604d59cf048332ac360a7b6d783353