### PR TITLE
Fix aggregation for task list estimated hours

### DIFF
--- a/todo/models.py
+++ b/todo/models.py
@@ -239,7 +239,10 @@ class TaskList(TimeStampedModel):
         if not self.pk:
             return Decimal('0.00')
         return self.tasks.aggregate(
-            total=models.Sum('total_hours')
+            total=models.Sum(
+                models.F('allotted_time') * models.F('team_size'),
+                output_field=models.DecimalField(max_digits=16, decimal_places=2)
+            )
         )['total'] or Decimal('0.00')
 
     @property


### PR DESCRIPTION
## Summary
- compute total estimated hours using `allotted_time` and `team_size`

## Testing
- `pytest -q` *(fails: SECRET_KEY not found / multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68604f02706c8332b6381e43d28d27b1