### PR TITLE
Fix user settings attribute lookup

### DIFF
--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -253,7 +253,7 @@ class AbstractTicketForm(CustomFieldMixin, forms.Form):
 
         if ticket.assigned_to and \
                 ticket.assigned_to != user and \
-                ticket.assigned_to.usersettings_helpdesk.settings.get('email_on_ticket_assign', False) and \
+                ticket.assigned_to.helpdesk_settings.settings.get('email_on_ticket_assign', False) and \
                 ticket.assigned_to.email and \
                 ticket.assigned_to.email not in messages_sent_to:
             send_templated_mail(

--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -32,7 +32,7 @@ def homepage(request):
             (request.user.is_authenticated and
              helpdesk_settings.HELPDESK_ALLOW_NON_STAFF_TICKET_UPDATE):
         try:
-            if request.user.usersettings_helpdesk.settings.get('login_view_ticketlist', False):
+            if request.user.helpdesk_settings.settings.get('login_view_ticketlist', False):
                 return HttpResponseRedirect(reverse('helpdesk:list'))
             else:
                 return HttpResponseRedirect(reverse('helpdesk:dashboard'))

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -589,10 +589,10 @@ def update_ticket(request, ticket_id, public=False):
 
         if (not reassigned or
                 (reassigned and
-                    ticket.assigned_to.usersettings_helpdesk.settings.get(
+                    ticket.assigned_to.helpdesk_settings.settings.get(
                         'email_on_ticket_assign', False))) or \
             (not reassigned and
-                ticket.assigned_to.usersettings_helpdesk.settings.get(
+                ticket.assigned_to.helpdesk_settings.settings.get(
                     'email_on_ticket_change', False)):
             send_templated_mail(
                 template_staff,
@@ -933,7 +933,7 @@ def ticket_list(request):
     return render(request, 'helpdesk/ticket_list.html', dict(
         context,
         tickets=ticket_qs,
-        default_tickets_per_page=request.user.usersettings_helpdesk.settings.get('tickets_per_page') or 25,
+        default_tickets_per_page=request.user.helpdesk_settings.settings.get('tickets_per_page') or 25,
         user_choices=User.objects.filter(is_active=True, is_staff=True),
         queue_choices=user_queues,
         status_choices=Ticket.STATUS_CHOICES,
@@ -986,7 +986,7 @@ def create_ticket(request):
                 return HttpResponseRedirect(reverse('helpdesk:dashboard'))
     else:
         initial_data = {}
-        if request.user.usersettings_helpdesk.settings.get('use_email_as_submitter', False) and request.user.email:
+        if request.user.helpdesk_settings.settings.get('use_email_as_submitter', False) and request.user.email:
             initial_data['submitter_email'] = request.user.email
         if 'queue' in request.GET:
             initial_data['queue'] = request.GET['queue']
@@ -1329,7 +1329,7 @@ def delete_saved_query(request, id):
 
 @staff_member_required
 def user_settings(request):
-    s = request.user.usersettings_helpdesk
+    s = request.user.helpdesk_settings
     if request.POST:
         form = UserSettingsForm(request.POST)
         if form.is_valid():


### PR DESCRIPTION
## Summary
- update the code to use the correct `helpdesk_settings` related name

## Testing
- `python -m pip install -r requirements.txt`
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: NOT NULL constraint failed)*

------
https://chatgpt.com/codex/tasks/task_e_68605e595bc48332b0620af880aafa2c