### PR TITLE
Fix static tag library

### DIFF
--- a/helpdesk/templates/helpdesk/base.html
+++ b/helpdesk/templates/helpdesk/base.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load saved_queries %}
 {% load load_helpdesk_settings %}
-{% load static from staticfiles %}
+{% load static %}
 {% with request|load_helpdesk_settings as helpdesk_settings %}
 {% with user|saved_queries as user_saved_queries_ %}
 <!DOCTYPE html>

--- a/helpdesk/templates/helpdesk/public_base.html
+++ b/helpdesk/templates/helpdesk/public_base.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load load_helpdesk_settings %}
-{% load static from staticfiles %}
+{% load static %}
 {% with request|load_helpdesk_settings as helpdesk_settings %}
 <!DOCTYPE html>
 <html lang="en">

--- a/helpdesk/templates/helpdesk/public_view_ticket.html
+++ b/helpdesk/templates/helpdesk/public_view_ticket.html
@@ -1,5 +1,5 @@
 {% extends "helpdesk/public_base.html" %}{% load i18n humanize %}
-{% load static from staticfiles %}
+{% load static %}
 {% block helpdesk_title %}{% trans "View a Ticket" %}{% endblock %}
 
 {% block helpdesk_body %}

--- a/helpdesk/templates/helpdesk/report_output.html
+++ b/helpdesk/templates/helpdesk/report_output.html
@@ -1,5 +1,5 @@
 {% extends "helpdesk/base.html" %}{% load i18n %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block helpdesk_title %}{% trans "Reports &amp; Statistics" %}{% endblock %}
 

--- a/helpdesk/templates/helpdesk/rss_list.html
+++ b/helpdesk/templates/helpdesk/rss_list.html
@@ -1,5 +1,5 @@
 {% extends "helpdesk/base.html" %}{% load i18n %}
-{% load static from staticfiles %}
+{% load static %}
 {% block helpdesk_title %}{% trans "RSS Feeds" %}{% endblock %}
 {% block helpdesk_body %}
 <h2>{% trans "RSS Feeds" %}</h2>

--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -1,6 +1,6 @@
 {% extends "helpdesk/base.html" %}
 {% load i18n humanize %}
-{% load static from staticfiles %}
+{% load static %}
 {% block helpdesk_title %}{{ ticket.queue.slug }}-{{ ticket.id }} : {% trans "View Ticket Details" %}{% endblock %}
 {% block helpdesk_head %}
 <script type='text/javascript' language='javascript'>

--- a/helpdesk/templates/helpdesk/ticket_desc_table.html
+++ b/helpdesk/templates/helpdesk/ticket_desc_table.html
@@ -1,5 +1,5 @@
 {% load i18n humanize ticket_to_link %}
-{% load static from staticfiles %}
+{% load static %}
 
 <div class="row">
                 <div class="col-lg-12">

--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -1,6 +1,6 @@
 {% extends "helpdesk/base.html" %}
 {% load i18n humanize %}
-{% load static from staticfiles %}
+{% load static %}
 {% block helpdesk_title %}{% trans "Tickets" %}{% endblock %}
 {% block helpdesk_head %}
 


### PR DESCRIPTION
## Summary
- update templates to use `{% load static %}` instead of deprecated `{% load static from staticfiles %}`

## Testing
- `python manage.py check`
- `pytest -q` *(fails: 89 failed, 23 passed, 13 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860601452f083328c68f379864f308a