### PR TITLE
Fix missing username attribute for Worker model

### DIFF
--- a/hr/models.py
+++ b/hr/models.py
@@ -470,6 +470,15 @@ class Worker(AbstractBaseUser, UUIDModel, TimeStampedModel):
         if self.preferred_name:
             return f"{self.preferred_name} {self.last_name}"
         return self.get_full_name()
+
+    # ------------------------------------------------------------------
+    # Compatibility helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def username(self):
+        """Alias for the user identifier used in templates and legacy code."""
+        return self.email
     
     # Permission methods (required by Django)
     def has_perm(self, perm, obj=None):


### PR DESCRIPTION
## Summary
- add `username` property to `Worker` model for compatibility

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: `django.db.utils.IntegrityError: NOT NULL constraint failed`)*


------
https://chatgpt.com/codex/tasks/task_e_68608cca96608332a243c93731722759