### PR TITLE
Improve project forms with admin-like widgets

### DIFF
--- a/project/templates/project/device_form.html
+++ b/project/templates/project/device_form.html
@@ -1,5 +1,11 @@
 {% extends "home/base.html" %}
+{% load static %}
 {% block title %}{% if form.instance.pk %}Edit {{ material_type }}{% else %}Add {{ material_type }}{% endif %}{% endblock %}
+{% block extra_js %}
+{{ form.media }}
+<script src="{% static 'admin/js/admin/RelatedObjectLookups.js' %}"></script>
+<script src="{% static 'admin/js/popup_response.js' %}"></script>
+{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:project-detail' project.job_number %}">{{ project.job_number }}</a></li>
 <li class="breadcrumb-item"><a href="{% url list_url_name project.job_number %}">{{ material_type }}s</a></li>
@@ -15,7 +21,18 @@
       <div class="card-body">
         <form method="post" enctype="multipart/form-data">
           {% csrf_token %}
-          {{ form.as_p }}
+          {% for field in form %}
+          <div class="mb-3">
+            {{ field.label_tag }}
+            {{ field }}
+            {% if field.help_text %}
+            <div class="form-text">{{ field.help_text }}</div>
+            {% endif %}
+            {% for error in field.errors %}
+            <div class="text-danger">{{ error }}</div>
+            {% endfor %}
+          </div>
+          {% endfor %}
           <div class="text-end">
             <button type="submit" class="btn btn-primary">Save</button>
           </div>

--- a/project/templates/project/project_form.html
+++ b/project/templates/project/project_form.html
@@ -1,5 +1,11 @@
 {% extends "home/base.html" %}
+{% load static %}
 {% block title %}{% if form.instance.pk %}Edit Project{% else %}New Project{% endif %}{% endblock %}
+{% block extra_js %}
+{{ form.media }}
+<script src="{% static 'admin/js/admin/RelatedObjectLookups.js' %}"></script>
+<script src="{% static 'admin/js/popup_response.js' %}"></script>
+{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:dashboard' %}">Projects</a></li>
 <li class="breadcrumb-item"><a href="{% url 'project:project-list' %}">List</a></li>
@@ -21,7 +27,18 @@
       <div class="card-body">
         <form method="post" enctype="multipart/form-data">
           {% csrf_token %}
-          {{ form.as_p }}
+          {% for field in form %}
+          <div class="mb-3">
+            {{ field.label_tag }}
+            {{ field }}
+            {% if field.help_text %}
+            <div class="form-text">{{ field.help_text }}</div>
+            {% endif %}
+            {% for error in field.errors %}
+            <div class="text-danger">{{ error }}</div>
+            {% endfor %}
+          </div>
+          {% endfor %}
           <div class="text-end">
             <button type="submit" class="btn btn-primary">Save</button>
           </div>

--- a/project/templates/project/project_status_form.html
+++ b/project/templates/project/project_status_form.html
@@ -1,5 +1,11 @@
 {% extends "home/base.html" %}
+{% load static %}
 {% block title %}Update Status - {{ project.name }}{% endblock %}
+{% block extra_js %}
+{{ form.media }}
+<script src="{% static 'admin/js/admin/RelatedObjectLookups.js' %}"></script>
+<script src="{% static 'admin/js/popup_response.js' %}"></script>
+{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:dashboard' %}">Projects</a></li>
 <li class="breadcrumb-item"><a href="{% url 'project:project-detail' project.job_number %}">{{ project.name }}</a></li>
@@ -15,7 +21,18 @@
       <div class="card-body">
         <form method="post">
           {% csrf_token %}
-          {{ form.as_p }}
+          {% for field in form %}
+          <div class="mb-3">
+            {{ field.label_tag }}
+            {{ field }}
+            {% if field.help_text %}
+            <div class="form-text">{{ field.help_text }}</div>
+            {% endif %}
+            {% for error in field.errors %}
+            <div class="text-danger">{{ error }}</div>
+            {% endfor %}
+          </div>
+          {% endfor %}
           <div class="text-end">
             <button type="submit" class="btn btn-primary">Save</button>
           </div>

--- a/project/templates/project/scope_form.html
+++ b/project/templates/project/scope_form.html
@@ -1,5 +1,11 @@
 {% extends "home/base.html" %}
+{% load static %}
 {% block title %}{% if form.instance.pk %}Edit Scope{% else %}Add Scope{% endif %}{% endblock %}
+{% block extra_js %}
+{{ form.media }}
+<script src="{% static 'admin/js/admin/RelatedObjectLookups.js' %}"></script>
+<script src="{% static 'admin/js/popup_response.js' %}"></script>
+{% endblock %}
 {% block breadcrumb %}
 <li class="breadcrumb-item"><a href="{% url 'project:project-detail' project.job_number %}">{{ project.job_number }}</a></li>
 <li class="breadcrumb-item"><a href="{% url 'project:scope-list' job_number=project.job_number %}">Scope of Work</a></li>
@@ -15,7 +21,18 @@
       <div class="card-body">
         <form method="post">
           {% csrf_token %}
-          {{ form.as_p }}
+          {% for field in form %}
+          <div class="mb-3">
+            {{ field.label_tag }}
+            {{ field }}
+            {% if field.help_text %}
+            <div class="form-text">{{ field.help_text }}</div>
+            {% endif %}
+            {% for error in field.errors %}
+            <div class="text-danger">{{ error }}</div>
+            {% endfor %}
+          </div>
+          {% endfor %}
           <div class="text-end">
             <button type="submit" class="btn btn-primary">Save</button>
           </div>


### PR DESCRIPTION
## Summary
- add `AdminWidgetsMixin` to wrap related fields with Django admin widgets
- update project forms to use the mixin
- clean up project-related form templates and include JS for related object popups

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'decouple')*
- `flake8` *(fails: multiple style violations)*

------
https://chatgpt.com/codex/tasks/task_e_6860900ee1a4833281adcb4e6962cfa4