### PR TITLE
Add starter templates for business app

### DIFF
--- a/business/templates/business/apply_template_confirm.html
+++ b/business/templates/business/apply_template_confirm.html
@@ -1,0 +1,18 @@
+{% extends "business/base_business.html" %}
+
+{% block business_title %}Apply Template{% endblock %}
+
+{% block business_breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'business:template-list' %}">Templates</a></li>
+<li class="breadcrumb-item active">Apply Template</li>
+{% endblock %}
+
+{% block business_content %}
+<h1 class="mb-4">Apply {{ template.name }} to {{ company.company_name }}</h1>
+<form method="post">
+    {% csrf_token %}
+    <p>Are you sure you want to apply this template to {{ company.company_name }}?</p>
+    <button type="submit" class="btn btn-primary">Apply Template</button>
+    <a href="{% url 'company:detail' company.id %}" class="btn btn-secondary">Cancel</a>
+</form>
+{% endblock %}

--- a/business/templates/business/base_business.html
+++ b/business/templates/business/base_business.html
@@ -1,0 +1,15 @@
+{% extends "home/base.html" %}
+{% load static %}
+
+{% block title %}{% block business_title %}Business Management{% endblock %}{% endblock %}
+
+{% block breadcrumb %}
+    <li class="breadcrumb-item"><a href="{% url 'business:dashboard' %}">Business</a></li>
+    {% block business_breadcrumb %}{% endblock %}
+{% endblock %}
+
+{% block content %}
+<div class="container-fluid">
+    {% block business_content %}{% endblock %}
+</div>
+{% endblock %}

--- a/business/templates/business/configuration_detail.html
+++ b/business/templates/business/configuration_detail.html
@@ -1,0 +1,31 @@
+{% extends "business/base_business.html" %}
+
+{% block business_title %}{{ config.name }}{% endblock %}
+
+{% block business_breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'business:config-list' %}">Configurations</a></li>
+<li class="breadcrumb-item active">{{ config.name }}</li>
+{% endblock %}
+
+{% block business_content %}
+<h1 class="mb-4">{{ config.name }}</h1>
+<p>{{ config.description }}</p>
+
+<h3>Project Categories</h3>
+<ul class="list-group mb-4">
+    {% for cat in project_categories %}
+    <li class="list-group-item">{{ cat.name }}</li>
+    {% empty %}
+    <li class="list-group-item">No categories configured.</li>
+    {% endfor %}
+</ul>
+
+<h3>Companies Using This Configuration</h3>
+<ul class="list-group">
+    {% for company in companies %}
+    <li class="list-group-item">{{ company.company_name }}</li>
+    {% empty %}
+    <li class="list-group-item">No companies.</li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/business/templates/business/configuration_list.html
+++ b/business/templates/business/configuration_list.html
@@ -1,0 +1,33 @@
+{% extends "business/base_business.html" %}
+
+{% block business_title %}Business Configurations{% endblock %}
+
+{% block business_breadcrumb %}
+<li class="breadcrumb-item active">Configurations</li>
+{% endblock %}
+
+{% block business_content %}
+<h1 class="mb-4">Business Configurations</h1>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Deployment</th>
+            <th>Billing</th>
+            <th>Companies</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for config in configurations %}
+        <tr>
+            <td><a href="{% url 'business:config-detail' config.slug %}">{{ config.name }}</a></td>
+            <td>{{ config.get_deployment_type_display }}</td>
+            <td>{{ config.get_billing_model_display }}</td>
+            <td>{{ config.companies_count }}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="4" class="text-center">No configurations found.</td></tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/business/templates/business/dashboard.html
+++ b/business/templates/business/dashboard.html
@@ -1,0 +1,40 @@
+{% extends "business/base_business.html" %}
+
+{% block business_title %}Business Dashboard{% endblock %}
+
+{% block business_breadcrumb %}
+<li class="breadcrumb-item active">Dashboard</li>
+{% endblock %}
+
+{% block business_content %}
+<h1 class="mb-4">Business Dashboard</h1>
+<div class="row g-4">
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title">Configurations</h5>
+                <p class="display-6">{{ total_configurations }}</p>
+                <a href="{% url 'business:config-list' %}" class="btn btn-primary">View</a>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title">Business Types</h5>
+                <p class="display-6">{{ total_business_types }}</p>
+                <a href="{% url 'business:type-list' %}" class="btn btn-primary">View</a>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title">Templates</h5>
+                <p class="display-6">{{ total_templates }}</p>
+                <a href="{% url 'business:template-list' %}" class="btn btn-primary">View</a>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/business/templates/business/setup_wizard_step1.html
+++ b/business/templates/business/setup_wizard_step1.html
@@ -1,0 +1,18 @@
+{% extends "business/base_business.html" %}
+
+{% block business_title %}Business Setup - Step 1{% endblock %}
+
+{% block business_breadcrumb %}
+<li class="breadcrumb-item active">Setup Step 1</li>
+{% endblock %}
+
+{% block business_content %}
+<h1 class="mb-4">Select Business Type</h1>
+<ul class="list-group">
+    {% for bt in business_types %}
+    <li class="list-group-item">
+        <a href="{% url 'business:setup-wizard' %}?step=2&amp;business_type={{ bt.slug }}">{{ bt.icon }} {{ bt.name }}</a>
+    </li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/business/templates/business/setup_wizard_step2.html
+++ b/business/templates/business/setup_wizard_step2.html
@@ -1,0 +1,26 @@
+{% extends "business/base_business.html" %}
+
+{% block business_title %}Business Setup - Step 2{% endblock %}
+
+{% block business_breadcrumb %}
+<li class="breadcrumb-item active">Setup Step 2</li>
+{% endblock %}
+
+{% block business_content %}
+<h1 class="mb-4">Choose Configuration</h1>
+<ul class="list-group mb-4">
+    {% for config in configurations %}
+    <li class="list-group-item">
+        <a href="{% url 'business:setup-wizard' %}?step=3&amp;business_type={{ business_type.slug }}&amp;config={{ config.slug }}">{{ config.name }}</a>
+    </li>
+    {% endfor %}
+</ul>
+<h2 class="mt-4">Or Select a Template</h2>
+<ul class="list-group">
+    {% for t in templates %}
+    <li class="list-group-item">
+        <a href="{% url 'business:setup-wizard' %}?step=3&amp;business_type={{ business_type.slug }}&amp;template={{ t.slug }}">{{ t.name }}</a>
+    </li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/business/templates/business/setup_wizard_step3.html
+++ b/business/templates/business/setup_wizard_step3.html
@@ -1,0 +1,19 @@
+{% extends "business/base_business.html" %}
+
+{% block business_title %}Business Setup - Step 3{% endblock %}
+
+{% block business_breadcrumb %}
+<li class="breadcrumb-item active">Setup Step 3</li>
+{% endblock %}
+
+{% block business_content %}
+<h1 class="mb-4">Review Selection</h1>
+{% if template %}
+<h3>Template: {{ template.name }}</h3>
+<p>{{ template.description }}</p>
+{% endif %}
+{% if config %}
+<h3>Configuration: {{ config.name }}</h3>
+<p>{{ config.description }}</p>
+{% endif %}
+{% endblock %}

--- a/business/templates/business/template_detail.html
+++ b/business/templates/business/template_detail.html
@@ -1,0 +1,23 @@
+{% extends "business/base_business.html" %}
+
+{% block business_title %}{{ template.name }}{% endblock %}
+
+{% block business_breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'business:template-list' %}">Templates</a></li>
+<li class="breadcrumb-item active">{{ template.name }}</li>
+{% endblock %}
+
+{% block business_content %}
+<h1 class="mb-4">{{ template.name }}</h1>
+<p>{{ template.description }}</p>
+
+<h3>Categories</h3>
+<ul class="list-group mb-4">
+    {% for cat in categories %}
+    <li class="list-group-item">{{ cat.name }}</li>
+    {% empty %}
+    <li class="list-group-item">No categories defined.</li>
+    {% endfor %}
+</ul>
+
+{% endblock %}

--- a/business/templates/business/template_list.html
+++ b/business/templates/business/template_list.html
@@ -1,0 +1,26 @@
+{% extends "business/base_business.html" %}
+
+{% block business_title %}Business Templates{% endblock %}
+
+{% block business_breadcrumb %}
+<li class="breadcrumb-item active">Templates</li>
+{% endblock %}
+
+{% block business_content %}
+<h1 class="mb-4">Business Templates</h1>
+<div class="row row-cols-1 row-cols-md-2 g-4">
+    {% for template in templates %}
+    <div class="col">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">{{ template.name }}</h5>
+                <p>{{ template.description }}</p>
+                <a href="{% url 'business:template-detail' template.slug %}" class="stretched-link"></a>
+            </div>
+        </div>
+    </div>
+    {% empty %}
+    <p>No templates found.</p>
+    {% endfor %}
+</div>
+{% endblock %}

--- a/business/templates/business/type_detail.html
+++ b/business/templates/business/type_detail.html
@@ -1,0 +1,22 @@
+{% extends "business/base_business.html" %}
+
+{% block business_title %}{{ business_type.name }}{% endblock %}
+
+{% block business_breadcrumb %}
+<li class="breadcrumb-item"><a href="{% url 'business:type-list' %}">Business Types</a></li>
+<li class="breadcrumb-item active">{{ business_type.name }}</li>
+{% endblock %}
+
+{% block business_content %}
+<h1 class="mb-4">{{ business_type.icon }} {{ business_type.name }}</h1>
+<p>{{ business_type.description }}</p>
+
+<h3>Project Categories</h3>
+<ul class="list-group mb-4">
+    {% for cat in project_categories %}
+    <li class="list-group-item">{{ cat.name }}</li>
+    {% empty %}
+    <li class="list-group-item">No categories defined.</li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/business/templates/business/type_list.html
+++ b/business/templates/business/type_list.html
@@ -1,0 +1,26 @@
+{% extends "business/base_business.html" %}
+
+{% block business_title %}Business Types{% endblock %}
+
+{% block business_breadcrumb %}
+<li class="breadcrumb-item active">Business Types</li>
+{% endblock %}
+
+{% block business_content %}
+<h1 class="mb-4">Business Types</h1>
+<div class="row row-cols-1 row-cols-md-2 g-4">
+    {% for bt in business_types %}
+    <div class="col">
+        <div class="card h-100">
+            <div class="card-body">
+                <h5 class="card-title">{{ bt.icon }} {{ bt.name }}</h5>
+                <p>{{ bt.description }}</p>
+                <a href="{% url 'business:type-detail' bt.slug %}" class="stretched-link"></a>
+            </div>
+        </div>
+    </div>
+    {% empty %}
+    <p>No business types found.</p>
+    {% endfor %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create base template for business views
- add dashboard, list, and detail pages for business app
- include setup wizard and apply-template templates

## Testing
- `pytest -q` *(fails: Module errors and test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686096a22f2c833291a331e12caef701