### PR TITLE
Fix debug toolbar url configuration

### DIFF
--- a/wbee/urls.py
+++ b/wbee/urls.py
@@ -37,6 +37,11 @@ urlpatterns = [
     path('wip/', include('wip.urls')),
 ]
 
+# Include Django debug toolbar URLs in development
+if settings.DEBUG and 'debug_toolbar' in settings.INSTALLED_APPS:
+    import debug_toolbar
+    urlpatterns = [path("__debug__/", include(debug_toolbar.urls))] + urlpatterns
+
 # Add Django site authentication urls (for login, logout, password management)
 urlpatterns += [
     path("accounts/", include("django.contrib.auth.urls")),


### PR DESCRIPTION
## Summary
- include Django debug toolbar URLs when running in DEBUG

## Testing
- `python manage.py test hr`
- `python manage.py test` *(fails: TemplateSyntaxError: 'bootstrap' is not a registered tag library)*

------
https://chatgpt.com/codex/tasks/task_e_6861e610b7b48332847096c66cca96a3