### PR TITLE
Fix missing hidden class in admin CSS

### DIFF
--- a/static/admin/css/modern-admin.css
+++ b/static/admin/css/modern-admin.css
@@ -43,3 +43,13 @@ button:hover, input[type="submit"]:hover {
 .admin-interface .module h2 {
     color: #0f172a;
 }
+
+/* Hide accessibility-only elements */
+.visually-hidden {
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px, 1px, 1px, 1px);
+    white-space: nowrap;
+}


### PR DESCRIPTION
## Summary
- hide accessibility helper headers in admin interface to avoid repeated "Add link" text

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6861e9665b088332bbe4cfc0ef8943f9