### PR TITLE
Disable admin_interface CSS

### DIFF
--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -2,5 +2,5 @@
 {% load static %}
 {% block extrastyle %}
     {{ block.super }}
-    <link rel="stylesheet" href="{% static 'admin/css/modern-admin.css' %}">
+    {# Removed custom modern-admin.css for a clean slate #}
 {% endblock %}

--- a/wbee/settings/base.py
+++ b/wbee/settings/base.py
@@ -26,8 +26,7 @@ GOOGLE_MAPS_API_KEY = config('GOOGLE_MAPS_API_KEY', default='')
 
 # Application definition
 DJANGO_APPS = [
-    'admin_interface',  # Modern admin skin
-    'colorfield',
+    # Removed 'admin_interface' and 'colorfield' for a simpler admin
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',


### PR DESCRIPTION
## Summary
- remove `admin_interface` and `colorfield` from installed apps
- drop the custom `modern-admin.css` link for a simpler admin layout

## Testing
- `python -m pip install -r requirements.txt`
- `python manage.py test` *(fails: 'bootstrap' tag not registered, fixture errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861edd38a088332a91c273c1afb50ab