### PR TITLE
Add admin link in user dropdown

### DIFF
--- a/home/templates/home/base.html
+++ b/home/templates/home/base.html
@@ -433,6 +433,11 @@
                             <li><a class="dropdown-item" href="#">
                                 <i class="fas fa-user-cog me-2"></i>Settings
                             </a></li>
+                            {% if user.is_admin %}
+                            <li><a class="dropdown-item" href="{% url 'admin:index' %}">
+                                <i class="fas fa-tools me-2"></i>Admin
+                            </a></li>
+                            {% endif %}
                             <li><a class="dropdown-item" href="{% url 'home:contact' %}">
                                 <i class="fas fa-envelope me-2"></i>Contact Support
                             </a></li>


### PR DESCRIPTION
## Summary
- allow admin users to access the Django admin from the user menu

## Testing
- `DATABASE_URL=sqlite:///:memory: python manage.py test` *(fails: bootstrap template tag not found and fixture loading errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864c5332a0c8332b5cae8dc3cc5feff