### PR TITLE
Expose HR role management

### DIFF
--- a/hr/admin.py
+++ b/hr/admin.py
@@ -25,7 +25,18 @@ class WorkerCreationForm(forms.ModelForm):
 
     class Meta:
         model = Worker
-        fields = ('email', 'first_name', 'last_name')
+        fields = (
+            'email',
+            'first_name',
+            'last_name',
+            'is_active',
+            'is_staff',
+            'is_admin',
+            'is_superuser',
+            'groups',
+            'user_permissions',
+            'roles',
+        )
 
     def clean_password2(self):
         # Check that the two password entries match
@@ -52,7 +63,19 @@ class WorkerChangeForm(forms.ModelForm):
 
     class Meta:
         model = Worker
-        fields = ('email', 'password', 'first_name', 'last_name', 'is_active', 'is_admin')
+        fields = (
+            'email',
+            'password',
+            'first_name',
+            'last_name',
+            'is_active',
+            'is_staff',
+            'is_admin',
+            'is_superuser',
+            'groups',
+            'user_permissions',
+            'roles',
+        )
 
     def clean_password(self):
         # Regardless of what the user provides, return the initial value.
@@ -76,7 +99,7 @@ class TimeoffInline(admin.TabularInline):
 @admin.register(Worker)
 class WorkerAdmin(BaseUserAdmin):
     # Override inherited filter_horizontal from BaseUserAdmin
-    filter_horizontal = ()  # Empty tuple - Worker model doesn't have groups/permissions
+    filter_horizontal = ('groups', 'user_permissions')
     
     # The forms to add and change worker instances
     form = WorkerChangeForm
@@ -175,7 +198,6 @@ class WorkerAdmin(BaseUserAdmin):
         ('Professional Information', {
             'fields': (
                 'skills',
-                'roles'
             ),
             'classes': ('collapse',)
         }),
@@ -191,7 +213,10 @@ class WorkerAdmin(BaseUserAdmin):
                 'is_active',
                 'is_staff',
                 'is_admin',
-                'is_superuser'
+                'is_superuser',
+                'roles',
+                'groups',
+                'user_permissions'
             )
         }),
         ('Time Off', {
@@ -219,13 +244,24 @@ class WorkerAdmin(BaseUserAdmin):
     add_fieldsets = (
         (None, {
             'classes': ('wide',),
-            'fields': ('email', 'first_name', 'last_name', 'password1', 'password2'),
+            'fields': (
+                'email',
+                'first_name',
+                'last_name',
+                'password1',
+                'password2',
+                'is_active',
+                'is_staff',
+                'is_admin',
+                'is_superuser',
+                'roles',
+                'groups',
+                'user_permissions',
+            ),
         }),
     )
 
-    # Note: Worker model doesn't have groups/user_permissions fields
-    # If you need these, your Worker model should extend User model
-    # filter_horizontal = ('groups', 'user_permissions',)
+    # Allow assignment of groups and explicit permissions
 
     actions = [
         'activate_workers',

--- a/hr/templates/hr/worker_form.html
+++ b/hr/templates/hr/worker_form.html
@@ -327,6 +327,37 @@
                         <small class="form-text text-muted">Uncheck to deactivate this worker account</small>
                     </div>
 
+                    <div class="form-check mt-2">
+                        {{ form.is_staff }}
+                        <label class="form-check-label" for="{{ form.is_staff.id_for_label }}">
+                            <strong>Staff Status</strong>
+                        </label>
+                    </div>
+
+                    <div class="form-check mt-2">
+                        {{ form.is_admin }}
+                        <label class="form-check-label" for="{{ form.is_admin.id_for_label }}">
+                            <strong>Admin Status</strong>
+                        </label>
+                    </div>
+
+                    <div class="form-check mt-2">
+                        {{ form.is_superuser }}
+                        <label class="form-check-label" for="{{ form.is_superuser.id_for_label }}">
+                            <strong>Superuser</strong>
+                        </label>
+                    </div>
+
+                    <div class="form-group mt-3">
+                        <label for="{{ form.groups.id_for_label }}" class="font-weight-bold">Groups</label>
+                        {{ form.groups }}
+                    </div>
+
+                    <div class="form-group">
+                        <label for="{{ form.user_permissions.id_for_label }}" class="font-weight-bold">User Permissions</label>
+                        {{ form.user_permissions }}
+                    </div>
+
                     <!-- Form Actions -->
                     <hr class="my-4">
                     <div class="row">

--- a/hr/views.py
+++ b/hr/views.py
@@ -154,7 +154,9 @@ class WorkerUpdateView(LoginRequiredMixin, PermissionRequiredMixin, UpdateView):
         'emergency_contact_relationship', 'date_of_birth', 'gender',
         'position', 'office', 'department', 'manager', 'employment_status',
         'date_of_hire', 'current_hourly_rate', 'current_annual_salary',
-        'bio', 'skills', 'profile_picture', 'resume', 'roles', 'is_active'
+        'bio', 'skills', 'profile_picture', 'resume', 'roles',
+        'groups', 'user_permissions',
+        'is_active', 'is_staff', 'is_admin', 'is_superuser'
     ]
     
     def form_valid(self, form):


### PR DESCRIPTION
## Summary
- allow HR admins to manage user groups and permissions
- show new permission fields on HR worker forms

## Testing
- `pytest -q` *(fails: UnknownSchemeError)*

------
https://chatgpt.com/codex/tasks/task_e_6864d5c8bf3883328c9ac8c58b77f44a