### PR TITLE
Add business client nickname synonyms

### DIFF
--- a/location/admin.py
+++ b/location/admin.py
@@ -64,6 +64,7 @@ class BusinessCategoryAdmin(admin.ModelAdmin):
     list_display = (
         'name',
         'project_terminology',
+        'client_nickname',
         'icon_display',
         'color_display',
         'location_count',
@@ -91,6 +92,15 @@ class BusinessCategoryAdmin(admin.ModelAdmin):
                 'project_nickname_singular'
             ),
             'description': 'Customize what "Projects" are called in this business type'
+        }),
+        ('Client Terminology', {
+            'fields': (
+                'client_nickname',
+                'client_nickname_singular',
+                'client_nickname_options'
+            ),
+            'description': 'Alternate names for clients',
+            'classes': ('collapse',)
         }),
         ('Visual Settings', {
             'fields': (

--- a/location/migrations/0003_businesscategory_client_nickname_options.py
+++ b/location/migrations/0003_businesscategory_client_nickname_options.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("location", "0002_businesscategory_client_nickname_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="businesscategory",
+            name="client_nickname_options",
+            field=models.JSONField(
+                default=list,
+                blank=True,
+                help_text="Optional alternate names for clients (Bar, Restaurant, etc.)",
+            ),
+        ),
+    ]

--- a/location/models.py
+++ b/location/models.py
@@ -61,6 +61,11 @@ class BusinessCategory(TimeStampedModel):
         default='Material',
         help_text='Singular material term'
     )
+    client_nickname_options = models.JSONField(
+        default=list,
+        blank=True,
+        help_text='Optional alternate names for clients (Bar, Restaurant, etc.)'
+    )
     material_type_nicknames = models.JSONField(
         default=dict,
         blank=True,
@@ -92,6 +97,10 @@ class BusinessCategory(TimeStampedModel):
     @property
     def client_term_singular(self):
         return self.client_nickname_singular
+
+    @property
+    def client_synonyms(self):
+        return self.client_nickname_options
 
     @property
     def location_term(self):
@@ -612,7 +621,10 @@ def create_default_business_categories():
             'icon': 'fas fa-truck',
             'color': '#27ae60',
             'project_nickname': 'Deliveries',
-            'project_nickname_singular': 'Delivery'
+            'project_nickname_singular': 'Delivery',
+            'client_nickname': 'Distribution Contracts',
+            'client_nickname_singular': 'Distribution Contract',
+            'client_nickname_options': ['Bar', 'Restaurant', 'Casino']
         }
     )[0]
     

--- a/tests/test_client_synonyms.py
+++ b/tests/test_client_synonyms.py
@@ -1,0 +1,31 @@
+from location.models import BusinessCategory
+from company.models import Company
+from hr.models import Worker
+from wbee.context_processors import terminology
+
+
+def test_client_synonyms_in_context(db):
+    bc = BusinessCategory.objects.create(
+        name="Brewery",
+        client_nickname="Distribution Contracts",
+        client_nickname_singular="Distribution Contract",
+        client_nickname_options=["Bar", "Restaurant", "Casino"],
+    )
+    company = Company.objects.create(
+        company_name="BrewCo",
+        primary_contact_name="Owner",
+        business_category=bc,
+    )
+    user = Worker.objects.create(
+        email="user@example.com",
+        employee_id="E1",
+        first_name="Test",
+        last_name="User",
+        company=company,
+    )
+    request = type("Req", (), {"user": user})
+    data = terminology(request)
+    terms = data["TERMINOLOGY"]
+    assert terms["client_plural"] == "Distribution Contracts"
+    assert terms["client_synonyms"] == ["Bar", "Restaurant", "Casino"]
+

--- a/wbee/context_processors/terminology.py
+++ b/wbee/context_processors/terminology.py
@@ -6,6 +6,7 @@ def terminology(request):
     defaults = {
         'client_plural': 'Clients',
         'client_singular': 'Client',
+        'client_synonyms': [],
         'location_plural': 'Locations',
         'location_singular': 'Location',
         'project_plural': 'Projects',
@@ -22,6 +23,7 @@ def terminology(request):
         defaults.update({
             'client_plural': category.client_term,
             'client_singular': category.client_term_singular,
+            'client_synonyms': category.client_synonyms,
             'location_plural': category.location_term,
             'location_singular': category.location_term_singular,
             'project_plural': category.project_term,


### PR DESCRIPTION
## Summary
- extend `BusinessCategory` with `client_nickname_options` JSON field
- expose `client_synonyms` via terminology context processor
- seed default synonyms for Distribution & Logistics
- update BusinessCategory admin with client terminology fields
- test new terminology behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6866116346288332bcc52d4d4314fd12