### PR TITLE
Add project asset assignments

### DIFF
--- a/asset/admin.py
+++ b/asset/admin.py
@@ -36,8 +36,8 @@ class AssetAssignmentInline(admin.TabularInline):
     model = AssetAssignment
     extra = 0
     fields = (
-        'assigned_to_worker', 'assigned_to_project', 'start_date', 
-        'end_date', 'purpose', 'is_active'
+        'assigned_to_worker', 'assigned_to_project', 'assigned_location',
+        'start_date', 'end_date', 'status', 'is_active'
     )
     readonly_fields = ('created_at',)
 
@@ -636,8 +636,10 @@ class AssetAssignmentAdmin(admin.ModelAdmin):
     list_display = (
         'asset',
         'assignment_display',
+        'assigned_location',
         'start_date',
         'end_date',
+        'status',
         'duration_display',
         'is_active'
     )
@@ -646,7 +648,8 @@ class AssetAssignmentAdmin(admin.ModelAdmin):
         'start_date',
         'end_date',
         'is_active',
-        'asset__category'
+        'asset__category',
+        'status'
     )
     
     search_fields = (
@@ -654,7 +657,8 @@ class AssetAssignmentAdmin(admin.ModelAdmin):
         'asset__name',
         'assigned_to_worker__first_name',
         'assigned_to_worker__last_name',
-        'assigned_to_project__name'
+        'assigned_to_project__name',
+        'assigned_location__name'
     )
     
     def assignment_display(self, obj):
@@ -662,6 +666,8 @@ class AssetAssignmentAdmin(admin.ModelAdmin):
             return f"👤 {obj.assigned_to_worker.first_name} {obj.assigned_to_worker.last_name}"
         elif obj.assigned_to_project:
             return f"📋 {obj.assigned_to_project.name}"
+        elif obj.assigned_location:
+            return f"📍 {obj.assigned_location.name}"
         elif obj.assigned_to_office:
             return f"🏢 {obj.assigned_to_office.office_name}"
         return "Unassigned"

--- a/asset/migrations/0004_asset_assignment_projects.py
+++ b/asset/migrations/0004_asset_assignment_projects.py
@@ -1,0 +1,40 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("asset", "0003_initial"),
+        ("project", "0001_initial"),
+        ("location", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="asset",
+            name="projects",
+            field=models.ManyToManyField(
+                blank=True,
+                related_name="assets",
+                through="asset.AssetAssignment",
+                through_fields=("asset", "assigned_to_project"),
+                to="project.project",
+            ),
+        ),
+        migrations.AddField(
+            model_name="assetassignment",
+            name="assigned_location",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="asset_assignments",
+                to="location.location",
+            ),
+        ),
+        migrations.AddField(
+            model_name="assetassignment",
+            name="status",
+            field=models.CharField(default="active", max_length=20),
+        ),
+    ]

--- a/asset/models.py
+++ b/asset/models.py
@@ -10,7 +10,12 @@ from django.utils.text import slugify
 
 # Import from your modernized apps
 from client.models import TimeStampedModel, UUIDModel
-from location.models import BusinessCategory, ConfigurableChoice, get_dynamic_choices
+from location.models import (
+    BusinessCategory,
+    ConfigurableChoice,
+    get_dynamic_choices,
+    Location,
+)
 from company.models import Company, Office, Department
 from hr.models import Worker, JobPosition
 from project.models import Project
@@ -214,6 +219,14 @@ class Asset(UUIDModel, TimeStampedModel):
         blank=True,
         related_name="project_assets",
         help_text="Project currently using this asset",
+    )
+
+    projects = models.ManyToManyField(
+        Project,
+        through="AssetAssignment",
+        through_fields=("asset", "assigned_to_project"),
+        related_name="assets",
+        blank=True,
     )
 
     # Dynamic status and location (configurable per business)
@@ -477,9 +490,19 @@ class AssetAssignment(TimeStampedModel):
         Office, on_delete=models.CASCADE, null=True, blank=True
     )
 
+    assigned_location = models.ForeignKey(
+        Location,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="asset_assignments",
+    )
+
     # Assignment period
     start_date = models.DateField(default=date.today)
     end_date = models.DateField(null=True, blank=True)
+
+    status = models.CharField(max_length=20, default="active")
 
     # Assignment details
     purpose = models.CharField(max_length=200, blank=True)

--- a/asset/tests.py
+++ b/asset/tests.py
@@ -1,3 +1,33 @@
 from django.test import TestCase
 
-# Create your tests here.
+from .models import Asset, AssetCategory, AssetAssignment
+from project.models import Project
+from location.models import BusinessCategory
+from company.models import Company
+
+
+class AssetAssignmentTests(TestCase):
+    def setUp(self):
+        self.bc = BusinessCategory.objects.create(name="Test")
+        self.company = Company.objects.create(
+            company_name="Co", primary_contact_name="PC", business_category=self.bc
+        )
+        self.category = AssetCategory.objects.create(
+            business_category=self.bc, name="Tool"
+        )
+        self.asset = Asset.objects.create(
+            asset_number="A1",
+            name="Asset1",
+            category=self.category,
+            asset_type="tool",
+            company=self.company,
+        )
+        self.project = Project.objects.create(job_number="P1", name="Proj1")
+
+    def test_asset_assignment_m2m(self):
+        AssetAssignment.objects.create(
+            asset=self.asset, assigned_to_project=self.project, status="active"
+        )
+
+        self.assertIn(self.project, self.asset.projects.all())
+        self.assertIn(self.asset, self.project.assets.all())

--- a/project/models.py
+++ b/project/models.py
@@ -501,6 +501,11 @@ class Project(UUIDModel, TimeStampedModel):
     def travel_items(self):
         return self.material_items.filter(material_type="travel")
 
+    @property
+    def allocated_assets(self):
+        """Return assets assigned to this project via assignments"""
+        return self.assets.all()
+
     def get_items_by_category(self, category_slug):
         """Return material items matching the given category slug"""
         return self.material_items.filter(material_type=category_slug)

--- a/project/tests.py
+++ b/project/tests.py
@@ -44,3 +44,27 @@ class ProjectLocationTests(TestCase):
         project.locations.add(loc1, loc2)
         self.assertEqual(project.primary_location, loc1)
         self.assertEqual(project.locations.count(), 2)
+
+
+class ProjectAssetTests(TestCase):
+    def test_allocated_assets_property(self):
+        from location.models import BusinessCategory
+        from company.models import Company
+        from asset.models import Asset, AssetCategory, AssetAssignment
+
+        bc = BusinessCategory.objects.create(name="BC")
+        company = Company.objects.create(
+            company_name="Co", primary_contact_name="PC", business_category=bc
+        )
+        category = AssetCategory.objects.create(business_category=bc, name="Tool")
+        asset = Asset.objects.create(
+            asset_number="A1",
+            name="Asset1",
+            category=category,
+            asset_type="tool",
+            company=company,
+        )
+        project = Project.objects.create(job_number="P1", name="Proj")
+        AssetAssignment.objects.create(asset=asset, assigned_to_project=project)
+
+        self.assertEqual(list(project.allocated_assets), [asset])

--- a/project/views.py
+++ b/project/views.py
@@ -374,6 +374,7 @@ class ProjectListView(LoginRequiredMixin, OptimizedQuerysetMixin, ListView):
         Prefetch(
             "milestones", queryset=ProjectMilestone.objects.filter(is_critical=True)
         ),
+        "assets",
     ]
     annotations = {
         # Count tasks via related task lists to avoid FieldError when
@@ -381,6 +382,7 @@ class ProjectListView(LoginRequiredMixin, OptimizedQuerysetMixin, ListView):
         "task_count": Count("task_lists__tasks", distinct=True),
         "team_size": Count("team_members", distinct=True),
         "milestone_count": Count("milestones"),
+        "asset_count": Count("assets", distinct=True),
     }
 
     def get_queryset(self):
@@ -497,6 +499,7 @@ class ProjectDetailView(ProjectAccessMixin, DetailView):
                 "material_items",
                 "changes",
                 "milestones",
+                "assets",
             )
         )
 
@@ -542,6 +545,8 @@ class ProjectDetailView(ProjectAccessMixin, DetailView):
             context["material_costs"] = project.calculate_material_costs()
         except:
             context["material_costs"] = {}
+
+        context["allocated_assets"] = project.allocated_assets
 
         # Recent activity
         context["recent_activity"] = self._get_recent_activity(project)


### PR DESCRIPTION
## Summary
- support assigning assets to projects
- expose related assets in project listings and detail pages
- update admin views for AssetAssignment
- create migrations and tests for new many-to-many relationship

## Testing
- `pytest asset/tests.py project/tests.py::ProjectAssetTests -q`

------
https://chatgpt.com/codex/tasks/task_e_686773a961548332a76f0c0fc2f30cca