### PR TITLE
Add fixtures and expand tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,73 @@
 import os
 import django
+import pytest
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "wbee.settings.base")
+from business.models import BusinessConfiguration
+from company.models import Company
+from client.models import Client, ServiceLocation
+from project.models import Project, ProjectMaterial
+from material.models import MaterialLifecycle
+from django.utils import timezone
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "wbee.settings.settings_test")
 os.environ.setdefault("SECRET_KEY", "test-secret")
 
 
 def pytest_configure():
     django.setup()
+
+
+@pytest.fixture
+def business_config(db):
+    return BusinessConfiguration.objects.create(name="Config")
+
+
+@pytest.fixture
+def company(business_config):
+    return Company.objects.create(
+        company_name="ACME",
+        primary_contact_name="Owner",
+        business_config=business_config,
+    )
+
+
+@pytest.fixture
+def client(company):
+    return Client.objects.create(company_name="ClientCo")
+
+
+@pytest.fixture
+def service_locations(client):
+    loc1 = ServiceLocation.objects.create(
+        client=client,
+        name="Location A",
+        line1="123 Main",
+        city="Town",
+        state_province="CA",
+        postal_code="11111",
+    )
+    loc2 = ServiceLocation.objects.create(
+        client=client,
+        name="Location B",
+        line1="456 Side",
+        city="Town",
+        state_province="CA",
+        postal_code="22222",
+    )
+    return [loc1, loc2]
+
+
+@pytest.fixture
+def project(service_locations):
+    p = Project.objects.create(job_number="JOB1", name="Test Project")
+    p.service_locations.set(service_locations)
+    return p
+
+
+@pytest.fixture
+def material_lifecycle(project):
+    pm = ProjectMaterial.objects.create(project=project, material_type="device")
+    return MaterialLifecycle.objects.create(
+        project_material=pm,
+        received_at=timezone.now(),
+    )

--- a/tests/test_business_type.py
+++ b/tests/test_business_type.py
@@ -1,4 +1,7 @@
-from business.models import BusinessType, ProjectCategory
+from business.models import BusinessType, ProjectCategory, TerminologyAlias, BusinessConfiguration
+from company.models import Company
+from hr.models import Worker
+from wbee.context_processors.terminology import terminology
 
 
 def test_business_type_and_category_creation(db):
@@ -6,3 +9,29 @@ def test_business_type_and_category_creation(db):
     cat = ProjectCategory.objects.create(business_type=bt, name="Equipment")
     assert bt.slug == "lawn-care"
     assert str(cat) == "Equipment (Lawn Care)"
+
+
+def test_terminology_alias_lookup(db):
+    config = BusinessConfiguration.objects.create(name="Alias Config")
+    TerminologyAlias.objects.create(
+        business_config=config,
+        app_label="client",
+        model="client",
+        field="company_name",
+        alias="Customer",
+    )
+    company = Company.objects.create(
+        company_name="TestCo",
+        primary_contact_name="Owner",
+        business_config=config,
+    )
+    user = Worker.objects.create(
+        email="user@example.com",
+        employee_id="E1",
+        first_name="Test",
+        last_name="User",
+        company=company,
+    )
+    request = type("Req", (), {"user": user})
+    data = terminology(request)
+    assert data["TERMINOLOGY"]["aliases"]["client.client.company_name"] == "Customer"

--- a/tests/test_client_synonyms.py
+++ b/tests/test_client_synonyms.py
@@ -1,7 +1,7 @@
 from location.models import BusinessCategory
 from company.models import Company
 from hr.models import Worker
-from wbee.context_processors import terminology
+from wbee.context_processors.terminology import terminology
 
 
 def test_client_synonyms_in_context(db):

--- a/tests/test_projectcategory.py
+++ b/tests/test_projectcategory.py
@@ -2,6 +2,11 @@ from location.models import BusinessCategory
 from project.models import ProjectCategory
 
 
+def test_project_multi_location_setup(project, service_locations):
+    assert project.service_locations.count() == 2
+    assert set(project.service_locations.all()) == set(service_locations)
+
+
 def test_project_category_creation(db):
     bc = BusinessCategory.objects.create(name="Test", icon="fa-test")
     cat = ProjectCategory.objects.create(


### PR DESCRIPTION
## Summary
- add reusable fixtures for common models
- test terminology alias via context processor
- test project multi-location relationships
- fix terminology import

## Testing
- `pytest tests/test_business_type.py tests/test_projectcategory.py tests/test_business_urls.py tests/test_client_synonyms.py tests/test_get_items_by_category.py tests/test_terminology_alias.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686773af45308332b9cf43685177c4ab