### PR TITLE
Fix location field references for project queries

### DIFF
--- a/client/admin.py
+++ b/client/admin.py
@@ -202,9 +202,9 @@ class ClientAdmin(admin.ModelAdmin):
         """Display number of projects across all locations"""
         try:
             from project.models import Project
-            count = Project.objects.filter(location__client=obj).count()  # Updated relationship
+            count = Project.objects.filter(locations__client=obj).count()  # Updated relationship
             if count > 0:
-                url = reverse('admin:project_project_changelist') + f'?location__client__id__exact={obj.id}'
+            url = reverse('admin:project_project_changelist') + f'?locations__client__id__exact={obj.id}'
                 return format_html('<a href="{}">{} projects</a>', url, count)
             return "0 projects"
         except:
@@ -225,7 +225,7 @@ class ClientAdmin(admin.ModelAdmin):
         """Display quick client statistics"""
         try:
             from project.models import Project
-            projects = Project.objects.filter(location__client=obj)  # Updated relationship
+            projects = Project.objects.filter(locations__client=obj)  # Updated relationship
             
             stats = {
                 'total_projects': projects.count(),

--- a/client/views.py
+++ b/client/views.py
@@ -242,7 +242,7 @@ class ClientDetailView(LoginRequiredMixin, generic.DetailView):
             # Compute from project contracts associated with this client
             from project.models import Project
             projects = Project.objects.filter(
-                location__client=client,
+                locations__client=client,
                 contract_value__isnull=False
             )
             if projects.exists():
@@ -690,7 +690,7 @@ class ClientEffortListView(LoginRequiredMixin, generic.ListView):
     def get_queryset(self):
         self.client = get_object_or_404(Client, pk=self.kwargs["pk"])
         return (
-            WIPItem.objects.filter(project__location__client=self.client)
+            WIPItem.objects.filter(project__locations__client=self.client)
             .select_related("project", "assigned_to")
             .order_by("-created_at")
         )

--- a/location/admin.py
+++ b/location/admin.py
@@ -401,11 +401,11 @@ class LocationAdmin(admin.ModelAdmin):
         """Display number of projects with business-specific terminology"""
         try:
             from project.models import Project
-            count = Project.objects.filter(location=obj).count()
+            count = Project.objects.filter(locations=obj).count()
             term = obj.project_term.lower() if count != 1 else obj.project_term_singular.lower()
             
             if count > 0:
-                url = reverse('admin:project_project_changelist') + f'?location__id__exact={obj.id}'
+                url = reverse('admin:project_project_changelist') + f'?locations__id__exact={obj.id}'
                 return format_html('<a href="{}">{} {}</a>', url, count, term)
             return f"0 {term}"
         except:
@@ -446,7 +446,7 @@ class LocationAdmin(admin.ModelAdmin):
         """Display quick location statistics"""
         try:
             from project.models import Project
-            projects = Project.objects.filter(location=obj)
+            projects = Project.objects.filter(locations=obj)
             
             stats = {
                 'total_projects': projects.count(),

--- a/location/models.py
+++ b/location/models.py
@@ -462,7 +462,7 @@ class Location(UUIDModel, TimeStampedModel):
         try:
             from project.models import Project  # Avoid circular import
             total = Project.objects.filter(
-                location=self
+                locations=self
             ).aggregate(
                 total=models.Sum('contract_value')
             )['total'] or Decimal('0.00')
@@ -477,7 +477,7 @@ class Location(UUIDModel, TimeStampedModel):
         """Get summary of project statuses at this location"""
         try:
             from project.models import Project
-            return Project.objects.filter(location=self).values('status').annotate(
+            return Project.objects.filter(locations=self).values('status').annotate(
                 count=models.Count('status')
             )
         except ImportError:

--- a/location/views.py
+++ b/location/views.py
@@ -62,7 +62,7 @@ def location_dashboard(request):
     try:
         from project.models import Project
         total_contract_value = Project.objects.filter(
-            location__in=locations
+            locations__in=locations
         ).aggregate(total=Sum('contract_value'))['total'] or 0
     except ImportError:
         total_contract_value = 0
@@ -178,7 +178,7 @@ class LocationDetailView(DetailView):
         try:
             from project.models import Project
             context['projects'] = Project.objects.filter(
-                location=location
+                locations=location
             ).order_by('-created_at')
             context['active_projects_count'] = context['projects'].exclude(
                 status__in=['c', 'm', 'l']

--- a/project/utils.py
+++ b/project/utils.py
@@ -13,7 +13,7 @@ def generate_job_number(business_category: Optional["BusinessCategory"] = None) 
     """
     qs = Project.objects.all()
     if business_category:
-        qs = qs.filter(location__business_category=business_category)
+        qs = qs.filter(locations__business_category=business_category)
 
     last_project = qs.order_by("-job_number").first()
     last_number = 0


### PR DESCRIPTION
## Summary
- update location dashboard and details to use new project `locations` relation
- update admin stats to reference `locations` many-to-many
- adjust helper function and client views/admin accordingly

## Testing
- `pip install -q -r requirements.txt` *(fails: network restrictions)*
- `pytest -q` *(fails: SECRET_KEY not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684ee5d4f48332b815438b41b81908