### PR TITLE
Fix format_html numeric usage

### DIFF
--- a/client/admin.py
+++ b/client/admin.py
@@ -454,8 +454,8 @@ class ProjectFinancialsAdmin(admin.ModelAdmin):
         variance = obj.labor_variance
         color = 'red' if variance > 0 else 'green'
         return format_html(
-            '<span style="color: {};">{:.2f} hours</span>',
-            color, variance
+            '<span style="color: {};">{}</span>',
+            color, f"{variance:.2f} hours"
         )
     labor_variance_display.short_description = 'Labor Variance'
     
@@ -463,7 +463,7 @@ class ProjectFinancialsAdmin(admin.ModelAdmin):
         variance = obj.material_variance
         color = 'red' if variance > 0 else 'green'
         return format_html(
-            '<span style="color: {};">${:,.2f}</span>',
-            color, variance
+            '<span style="color: {};">{}</span>',
+            color, f"${variance:,.2f}"
         )
     material_variance_display.short_description = 'Material Variance'

--- a/company/admin.py
+++ b/company/admin.py
@@ -282,13 +282,13 @@ class CompanyAdmin(admin.ModelAdmin):
         growth = obj.revenue_growth
         if growth > 0:
             return format_html(
-                '<span style="color: #28a745; font-weight: bold;">+{:.1f}%</span>',
-                growth
+                '<span style="color: #28a745; font-weight: bold;">{}</span>',
+                f"+{growth:.1f}%"
             )
         elif growth < 0:
             return format_html(
-                '<span style="color: #dc3545; font-weight: bold;">{:.1f}%</span>',
-                growth
+                '<span style="color: #dc3545; font-weight: bold;">{}</span>',
+                f"{growth:.1f}%"
             )
         else:
             return "0%"
@@ -486,8 +486,8 @@ class OfficeAdmin(admin.ModelAdmin):
                 color = '#28a745'  # Green - good utilization
             
             return format_html(
-                '<span style="color: {}; font-weight: bold;">{:.1f}%</span>',
-                color, rate
+                '<span style="color: {}; font-weight: bold;">{}</span>',
+                color, f"{rate:.1f}%"
             )
         return "—"
     utilization_display.short_description = 'Utilization'

--- a/material/admin.py
+++ b/material/admin.py
@@ -693,8 +693,8 @@ class ProductAdmin(admin.ModelAdmin):
             color = '#dc3545'
         
         return format_html(
-            '<span style="color: {}; font-weight: bold;">{:.1f}%</span>',
-            color, margin
+            '<span style="color: {}; font-weight: bold;">{}</span>',
+            color, f"{margin:.1f}%"
         )
     profit_margin_display.short_description = 'Margin'
 
@@ -874,9 +874,15 @@ class InventoryTransactionAdmin(admin.ModelAdmin):
     def quantity_display(self, obj):
         """Display quantity with +/- indicator"""
         if obj.quantity >= 0:
-            return format_html('<span style="color: #28a745;">+{:.2f}</span>', obj.quantity)
+            return format_html(
+                '<span style="color: #28a745;">{}</span>',
+                f"+{obj.quantity:.2f}"
+            )
         else:
-            return format_html('<span style="color: #dc3545;">{:.2f}</span>', obj.quantity)
+            return format_html(
+                '<span style="color: #dc3545;">{}</span>',
+                f"{obj.quantity:.2f}"
+            )
     quantity_display.short_description = 'Quantity'
 
     def stock_change(self, obj):

--- a/project/admin.py
+++ b/project/admin.py
@@ -397,12 +397,12 @@ class ProjectAdmin(admin.ModelAdmin):
             margin = float(obj.profit_margin)
             return format_html(
                 '<div style="font-size: 11px;">'
-                '<strong>${:,.0f}</strong><br>'
-                '<span style="color: {};">{:.1f}% margin</span>'
+                '<strong>{}</strong><br>'
+                '<span style="color: {};">{}% margin</span>'
                 '</div>',
-                contract,
+                f"${contract:,.0f}",
                 '#28a745' if obj.is_profitable else '#dc3545',
-                margin
+                f"{margin:.1f}"
             )
         return "—"
     financial_summary.short_description = 'Financial'
@@ -425,9 +425,9 @@ class ProjectAdmin(admin.ModelAdmin):
         margin = float(obj.profit_margin)
         color = '#28a745' if margin > 0 else '#dc3545'
         return format_html(
-            '<span style="color: {}; font-weight: bold;">{:.2f}%</span>',
+            '<span style="color: {}; font-weight: bold;">{}</span>',
             color,
-            margin
+            f"{margin:.2f}%"
         )
     profit_margin_display.short_description = 'Profit Margin'
 
@@ -436,9 +436,9 @@ class ProjectAdmin(admin.ModelAdmin):
         balance = float(obj.outstanding_balance)
         color = '#dc3545' if balance > 0 else '#28a745'
         return format_html(
-            '<span style="color: {}; font-weight: bold;">${:,.2f}</span>',
+            '<span style="color: {}; font-weight: bold;">{}</span>',
             color,
-            balance
+            f"${balance:,.2f}"
         )
     outstanding_balance_display.short_description = 'Outstanding Balance'
 
@@ -482,8 +482,8 @@ class ProjectAdmin(admin.ModelAdmin):
         if obj.total_tasks > 0:
             percent = obj.task_completion_percentage
             return format_html(
-                '{:.1f}% ({}/{})',
-                percent, obj.completed_tasks, obj.total_tasks
+                '{} ({}/{})',
+                f"{percent:.1f}%", obj.completed_tasks, obj.total_tasks
             )
         return "No tasks"
     task_completion_display.short_description = 'Task Completion'
@@ -629,9 +629,9 @@ class ScopeOfWorkAdmin(admin.ModelAdmin):
             val = float(variance)
             color = '#dc3545' if val > 0 else '#28a745'
             return format_html(
-                '<span style="color: {};">${:,.2f}</span>',
+                '<span style="color: {};">{}</span>',
                 color,
-                val
+                f"${val:,.2f}"
             )
         return "—"
     cost_variance_display.short_description = 'Cost Variance'
@@ -666,9 +666,15 @@ class ProjectChangeAdmin(admin.ModelAdmin):
         """Display cost impact with color coding"""
         impact = float(obj.cost_impact)
         if impact > 0:
-            return format_html('<span style="color: #dc3545;">+${:,.2f}</span>', impact)
+            return format_html(
+                '<span style="color: #dc3545;">{}</span>',
+                f"+${impact:,.2f}"
+            )
         elif impact < 0:
-            return format_html('<span style="color: #28a745;">${:,.2f}</span>', impact)
+            return format_html(
+                '<span style="color: #28a745;">{}</span>',
+                f"${impact:,.2f}"
+            )
         return "$0.00"
     cost_impact_display.short_description = 'Cost Impact'
     

--- a/schedule/admin.py
+++ b/schedule/admin.py
@@ -548,15 +548,18 @@ class EventAdmin(admin.ModelAdmin):
             variance = obj.cost_variance
             variance_color = '#dc3545' if variance > 0 else '#28a745'
             return format_html(
-                '<strong>${:.0f}</strong><br><small style="color: {};">Var: ${:.0f}</small>',
-                obj.actual_cost,
+                '<strong>{}</strong><br><small style="color: {};">Var: {}</small>',
+                f"${obj.actual_cost:.0f}",
                 variance_color,
-                variance
+                f"${variance:.0f}"
             )
         elif obj.estimated_cost:
-            return format_html('<strong>Est: ${:.0f}</strong>', obj.estimated_cost)
+            return format_html(
+                '<strong>Est: {}</strong>',
+                f"${obj.estimated_cost:.0f}"
+            )
         elif obj.actual_cost:
-            return format_html('<strong>${:.0f}</strong>', obj.actual_cost)
+            return format_html('<strong>{}</strong>', f"${obj.actual_cost:.0f}")
         return "No cost data"
     cost_summary.short_description = 'Cost'
 

--- a/timecard/admin.py
+++ b/timecard/admin.py
@@ -339,11 +339,11 @@ class TimeCardAdmin(admin.ModelAdmin):
     def hours_breakdown(self, obj):
         """Display hours breakdown"""
         return format_html(
-            '<strong>{:.2f}h</strong><br>'
-            '<small>Reg: {:.2f}h | OT: {:.2f}h</small>',
-            obj.total_hours,
-            obj.regular_hours,
-            obj.overtime_hours
+            '<strong>{}</strong><br>'
+            '<small>Reg: {}h | OT: {}h</small>',
+            f"{obj.total_hours:.2f}h",
+            f"{obj.regular_hours:.2f}",
+            f"{obj.overtime_hours:.2f}"
         )
     hours_breakdown.short_description = 'Hours'
 
@@ -371,9 +371,9 @@ class TimeCardAdmin(admin.ModelAdmin):
         
         if total_pay > 0:
             return format_html(
-                '<strong>${:.2f}</strong><br><small>@${:.2f}/hr</small>',
-                total_pay,
-                rate
+                '<strong>{}</strong><br><small>@{}/hr</small>',
+                f"${total_pay:.2f}",
+                f"${rate:.2f}"
             )
         return "—"
     pay_display.short_description = 'Pay'
@@ -634,19 +634,19 @@ class TimesheetSummaryAdmin(admin.ModelAdmin):
     def total_hours_display(self, obj):
         """Display total hours with breakdown"""
         return format_html(
-            '<strong>{:.1f}h</strong><br><small>R:{:.1f} | OT:{:.1f}</small>',
-            obj.total_hours,
-            obj.regular_hours,
-            obj.overtime_hours
+            '<strong>{}</strong><br><small>R:{} | OT:{}</small>',
+            f"{obj.total_hours:.1f}h",
+            f"{obj.regular_hours:.1f}",
+            f"{obj.overtime_hours:.1f}"
         )
     total_hours_display.short_description = 'Hours'
 
     def pay_summary(self, obj):
         """Display pay summary"""
         return format_html(
-            '<strong>${:.2f}</strong><br><small>+${:.2f} exp</small>',
-            obj.total_pay,
-            obj.total_expenses
+            '<strong>{}</strong><br><small>+{} exp</small>',
+            f"${obj.total_pay:.2f}",
+            f"${obj.total_expenses:.2f}"
         )
     pay_summary.short_description = 'Pay'
 
@@ -657,9 +657,15 @@ class TimesheetSummaryAdmin(admin.ModelAdmin):
         else:
             variance = obj.variance_hours
             if variance < 0:
-                return format_html('<span style="color: #ffc107;">⚠ Under ({:.1f}h)</span>', abs(variance))
+                return format_html(
+                    '<span style="color: #ffc107;">⚠ Under ({})</span>',
+                    f"{abs(variance):.1f}h"
+                )
             elif variance > 0:
-                return format_html('<span style="color: #fd7e14;">⚠ Over (+{:.1f}h)</span>', variance)
+                return format_html(
+                    '<span style="color: #fd7e14;">⚠ Over (+{})</span>',
+                    f"{variance:.1f}h"
+                )
             else:
                 return format_html('<span style="color: #007bff;">○ Exact</span>')
     completion_status.short_description = 'Completion'


### PR DESCRIPTION
## Summary
- prevent `format_html` errors on Django 5.2 by pre-formatting numeric values

## Testing
- `pytest -q` *(fails: Django not configured)*

------
https://chatgpt.com/codex/tasks/task_e_686956e2dfd48332b7123bd9e9a663c7