### PR TITLE
Update dashboard template with stats and tool counts

### DIFF
--- a/home/templates/home/home.html
+++ b/home/templates/home/home.html
@@ -169,6 +169,19 @@
     text-decoration: underline;
 }
 
+.card-header-count {
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: #f1f3f5;
+    color: #495057;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+}
+
+.card-header-title .card-header-count {
+    margin-left: 0.5rem;
+}
+
 .card-body {
     padding: 1.5rem;
 }
@@ -253,9 +266,19 @@
     font-weight: 600;
     display: flex;
     align-items: center;
+    justify-content: space-between;
+}
+
+.tools-header-title {
+    display: flex;
+    align-items: center;
     gap: 0.75rem;
 }
 
+.tools-header .card-header-count {
+    background: rgba(255, 255, 255, 0.2);
+    color: #fff;
+}
 .tools-category {
     border-bottom: 1px solid #e1e4e8;
 }
@@ -414,12 +437,12 @@
 <div class="stats-row">
     <div class="stat-card">
         <div class="stat-icon">
-            <i class="fas fa-box"></i>
+            <i class="fas fa-tools"></i>
         </div>
         <div class="stat-value">{{ dashboard_stats.total_assets|default:0 }}</div>
-        <div class="stat-label">Active Assets</div>
+        <div class="stat-label">Tools &amp; Equipment</div>
     </div>
-    
+
     <div class="stat-card success">
         <div class="stat-icon">
             <i class="fas fa-project-diagram"></i>
@@ -427,21 +450,21 @@
         <div class="stat-value">{{ dashboard_stats.active_projects|default:0 }}</div>
         <div class="stat-label">Active Projects</div>
     </div>
-    
+
     <div class="stat-card warning">
         <div class="stat-icon">
             <i class="fas fa-tasks"></i>
         </div>
         <div class="stat-value">{{ dashboard_stats.pending_tasks|default:0 }}</div>
-        <div class="stat-label">Pending Tasks</div>
+        <div class="stat-label">Priority Tasks</div>
     </div>
-    
+
     <div class="stat-card danger">
         <div class="stat-icon">
             <i class="fas fa-calendar-check"></i>
         </div>
         <div class="stat-value">{{ dashboard_stats.upcoming_events|default:0 }}</div>
-        <div class="stat-label">This Week</div>
+        <div class="stat-label">Scheduled Events</div>
     </div>
 </div>
 
@@ -502,6 +525,7 @@
                         <i class="fas fa-calendar-check"></i>
                     </div>
                     <span>Scheduled Events</span>
+                    <span class="card-header-count">{{ scheduled_events|length }}</span>
                 </div>
                 <a href="{% url 'schedule:schedule' %}" class="card-header-action">
                     View all <i class="fas fa-arrow-right ms-1"></i>
@@ -636,10 +660,13 @@
     <div class="sidebar-content">
         <div class="tools-section">
             <div class="tools-header">
-                <i class="fas fa-tools"></i>
-                <span>My Tools & Equipment</span>
+                <div class="tools-header-title">
+                    <i class="fas fa-tools"></i>
+                    <span>My Tools &amp; Equipment</span>
+                </div>
+                <span class="card-header-count">{{ dashboard_stats.total_assets|default:0 }}</span>
             </div>
-            
+
             {% if tools_assigned or ladder_list or vehicle_list or tool_list %}
                 {% if tools_assigned %}
                     {% for category in tools_assigned %}


### PR DESCRIPTION
## Summary
- align the dashboard stats row with the new view data for tools & equipment, active projects, tasks, and scheduled events
- show event and tool totals in their respective panels with updated header styling

## Testing
- Not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68eb1bb14d8c83328eaf79723a26fff9